### PR TITLE
Add various EntityTag tags/mecs

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
@@ -47,14 +47,14 @@ public class PropertyRegistry {
         PropertyParser.registerProperty(EntityBeamTarget.class, EntityTag.class);
         PropertyParser.registerProperty(EntityBodyArrows.class, EntityTag.class);
         PropertyParser.registerProperty(EntityBoundingBox.class, EntityTag.class);
-        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_14_R1)) {
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_14)) {
             PropertyParser.registerProperty(EntityCatType.class, EntityTag.class);
         }
-        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_13_R2)) {
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_13)) {
             PropertyParser.registerProperty(EntityCharging.class, EntityTag.class);
         }
         PropertyParser.registerProperty(EntityChestCarrier.class, EntityTag.class);
-        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_14_R1)) {
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_14)) {
             PropertyParser.registerProperty(EntityCollarColor.class, EntityTag.class);
         }
         PropertyParser.registerProperty(EntityColor.class, EntityTag.class);
@@ -67,7 +67,7 @@ public class PropertyRegistry {
         PropertyParser.registerProperty(EntityExplosionFire.class, EntityTag.class);
         PropertyParser.registerProperty(EntityExplosionRadius.class, EntityTag.class);
         PropertyParser.registerProperty(EntityFirework.class, EntityTag.class);
-        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_14_R1)) {
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_14)) {
             PropertyParser.registerProperty(EntityFoxCrouching.class, EntityTag.class);
             PropertyParser.registerProperty(EntityFoxType.class, EntityTag.class);
         }
@@ -82,11 +82,11 @@ public class PropertyRegistry {
         PropertyParser.registerProperty(EntityKnockback.class, EntityTag.class);
         PropertyParser.registerProperty(EntityMarker.class, EntityTag.class);
         PropertyParser.registerProperty(EntityMaxFuseTicks.class, EntityTag.class);
-        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_14_R1)) {
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_14)) {
             PropertyParser.registerProperty(EntityMooshroomVariant.class, EntityTag.class);
         }
         PropertyParser.registerProperty(EntityPainting.class, EntityTag.class);
-        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_14_R1)) {
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_14)) {
             PropertyParser.registerProperty(EntityPandaGene.class, EntityTag.class);
             PropertyParser.registerProperty(EntityPatrolLeader.class, EntityTag.class);
             PropertyParser.registerProperty(EntityPatrolTarget.class, EntityTag.class);

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
@@ -16,6 +16,7 @@ import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.core.ListTag;
 import com.denizenscript.denizencore.objects.core.QueueTag;
 import com.denizenscript.denizencore.objects.core.ScriptTag;
+import com.denizenscript.denizencore.objects.properties.Property;
 import com.denizenscript.denizencore.objects.properties.PropertyParser;
 
 public class PropertyRegistry {
@@ -46,7 +47,16 @@ public class PropertyRegistry {
         PropertyParser.registerProperty(EntityBeamTarget.class, EntityTag.class);
         PropertyParser.registerProperty(EntityBodyArrows.class, EntityTag.class);
         PropertyParser.registerProperty(EntityBoundingBox.class, EntityTag.class);
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_14_R1)) {
+            PropertyParser.registerProperty(EntityCatType.class, EntityTag.class);
+        }
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_13_R2)) {
+            PropertyParser.registerProperty(EntityCharging.class, EntityTag.class);
+        }
         PropertyParser.registerProperty(EntityChestCarrier.class, EntityTag.class);
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_14_R1)) {
+            PropertyParser.registerProperty(EntityCollarColor.class, EntityTag.class);
+        }
         PropertyParser.registerProperty(EntityColor.class, EntityTag.class);
         PropertyParser.registerProperty(EntityCritical.class, EntityTag.class);
         PropertyParser.registerProperty(EntityCustomName.class, EntityTag.class);
@@ -57,6 +67,10 @@ public class PropertyRegistry {
         PropertyParser.registerProperty(EntityExplosionFire.class, EntityTag.class);
         PropertyParser.registerProperty(EntityExplosionRadius.class, EntityTag.class);
         PropertyParser.registerProperty(EntityFirework.class, EntityTag.class);
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_14_R1)) {
+            PropertyParser.registerProperty(EntityFoxCrouching.class, EntityTag.class);
+            PropertyParser.registerProperty(EntityFoxType.class, EntityTag.class);
+        }
         PropertyParser.registerProperty(EntityFramed.class, EntityTag.class);
         PropertyParser.registerProperty(EntityGravity.class, EntityTag.class);
         PropertyParser.registerProperty(EntityHealth.class, EntityTag.class);
@@ -68,7 +82,15 @@ public class PropertyRegistry {
         PropertyParser.registerProperty(EntityKnockback.class, EntityTag.class);
         PropertyParser.registerProperty(EntityMarker.class, EntityTag.class);
         PropertyParser.registerProperty(EntityMaxFuseTicks.class, EntityTag.class);
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_14_R1)) {
+            PropertyParser.registerProperty(EntityMooshroomVariant.class, EntityTag.class);
+        }
         PropertyParser.registerProperty(EntityPainting.class, EntityTag.class);
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_14_R1)) {
+            PropertyParser.registerProperty(EntityPandaGene.class, EntityTag.class);
+            PropertyParser.registerProperty(EntityPatrolLeader.class, EntityTag.class);
+            PropertyParser.registerProperty(EntityPatrolTarget.class, EntityTag.class);
+        }
         PropertyParser.registerProperty(EntityPickupStatus.class, EntityTag.class);
         PropertyParser.registerProperty(EntityPotion.class, EntityTag.class);
         PropertyParser.registerProperty(EntityPowered.class, EntityTag.class);

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityCatType.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityCatType.java
@@ -1,0 +1,100 @@
+package com.denizenscript.denizen.objects.properties.entity;
+
+import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.objects.properties.Property;
+import com.denizenscript.denizencore.tags.Attribute;
+import org.bukkit.entity.Cat;
+import org.bukkit.entity.EntityType;
+
+public class EntityCatType implements Property {
+
+    public static boolean describes(ObjectTag entity) {
+        return entity instanceof EntityTag && ((EntityTag) entity).getBukkitEntityType() == EntityType.CAT;
+    }
+
+    public static EntityCatType getFrom(ObjectTag entity) {
+        if (!describes(entity)) {
+            return null;
+        }
+        return new EntityCatType((EntityTag) entity);
+    }
+
+    public static final String[] handledTags = new String[] {
+            "cat_type"
+    };
+
+    public static final String[] handledMechs = new String[] {
+            "cat_type"
+    };
+
+
+    ///////////////////
+    // Instance Fields and Methods
+    /////////////
+
+    private EntityCatType(EntityTag entity) {
+        this.entity = entity;
+    }
+
+    private EntityTag entity;
+
+    /////////
+    // Property Methods
+    ///////
+
+    @Override
+    public String getPropertyString() {
+        return ((Cat) entity.getBukkitEntity()).getCatType().name();
+    }
+
+    @Override
+    public String getPropertyId() {
+        return "cat_type";
+    }
+
+    ///////////
+    // ObjectTag Attributes
+    ////////
+
+    @Override
+    public String getAttribute(Attribute attribute) {
+        if (attribute == null) {
+            return null;
+        }
+
+        // <--[tag]
+        // @attribute <EntityTag.cat_type>
+        // @returns ElementTag
+        // @mechanism EntityTag.cat_type
+        // @group properties
+        // @description
+        // Returns the cat type of this entity.
+        // -->
+        if (attribute.startsWith("cat_type")) {
+            return new ElementTag(((Cat) entity.getBukkitEntity()).getCatType().name()).getAttribute(attribute.fulfill(1));
+        }
+
+        return null;
+    }
+
+    @Override
+    public void adjust(Mechanism mechanism) {
+
+        // <--[mechanism]
+        // @object EntityTag
+        // @name cat_type
+        // @input ElementTag
+        // @description
+        // Sets the cat type of this entity.
+        // Valid cat types are: <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/entity/Cat.Type.html>
+        // @tags
+        // <EntityTag.cat_type>
+        // -->
+        if (mechanism.matches("cat_type") && mechanism.requireEnum(false, Cat.Type.values())) {
+            ((Cat) entity.getBukkitEntity()).setCatType(Cat.Type.valueOf(mechanism.getValue().asString().toUpperCase()));
+        }
+    }
+}

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityCharging.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityCharging.java
@@ -47,7 +47,7 @@ public class EntityCharging implements Property {
 
     @Override
     public String getPropertyString() {
-        return ((Vex) entity.getBukkitEntity()).isCharging() ? "true" : null;
+        return String.valueOf(((Vex) entity.getBukkitEntity()).isCharging());
     }
 
     @Override

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityCharging.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityCharging.java
@@ -1,0 +1,100 @@
+package com.denizenscript.denizen.objects.properties.entity;
+
+import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.objects.properties.Property;
+import com.denizenscript.denizencore.tags.Attribute;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Vex;
+
+public class EntityCharging implements Property {
+
+    public static boolean describes(ObjectTag entity) {
+        return entity instanceof EntityTag && ((EntityTag) entity).getBukkitEntityType() == EntityType.VEX;
+    }
+
+    public static EntityCharging getFrom(ObjectTag entity) {
+        if (!describes(entity)) {
+            return null;
+        }
+        return new EntityCharging((EntityTag) entity);
+    }
+
+    public static final String[] handledTags = new String[] {
+            "is_charging"
+    };
+
+    public static final String[] handledMechs = new String[] {
+            "is_charging"
+    };
+
+
+    ///////////////////
+    // Instance Fields and Methods
+    /////////////
+
+    private EntityCharging(EntityTag entity) {
+        this.entity = entity;
+    }
+
+    private EntityTag entity;
+
+    /////////
+    // Property Methods
+    ///////
+
+    @Override
+    public String getPropertyString() {
+        return ((Vex) entity.getBukkitEntity()).isCharging() ? "true" : null;
+    }
+
+    @Override
+    public String getPropertyId() {
+        return "is_charging";
+    }
+
+    ///////////
+    // ObjectTag Attributes
+    ////////
+
+    @Override
+    public String getAttribute(Attribute attribute) {
+        if (attribute == null) {
+            return null;
+        }
+
+        // <--[tag]
+        // @attribute <EntityTag.is_charging>
+        // @returns ElementTag(Boolean)
+        // @mechanism EntityTag.is_charging
+        // @group properties
+        // @description
+        // If the entity is a vex, returns whether it is charging.
+        // If set to true, the Vex will have a red angry texture.
+        // -->
+        if (attribute.startsWith("is_charging")) {
+            return new ElementTag(((Vex) entity.getBukkitEntity()).isCharging()).getAttribute(attribute.fulfill(1));
+        }
+
+        return null;
+    }
+
+    @Override
+    public void adjust(Mechanism mechanism) {
+
+        // <--[mechanism]
+        // @object EntityTag
+        // @name is_charging
+        // @input ElementTag(Boolean)
+        // @description
+        // If the entity is a vex, sets the charging state of the entity.
+        // @tags
+        // <EntityTag.is_charging>
+        // -->
+        if (mechanism.matches("is_charging") && mechanism.requireBoolean()) {
+            ((Vex) entity.getBukkitEntity()).setCharging(mechanism.getValue().asBoolean());
+        }
+    }
+}

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityCollarColor.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityCollarColor.java
@@ -1,0 +1,123 @@
+package com.denizenscript.denizen.objects.properties.entity;
+
+import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.objects.properties.Property;
+import com.denizenscript.denizencore.tags.Attribute;
+import org.bukkit.DyeColor;
+import org.bukkit.entity.Cat;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Wolf;
+
+public class EntityCollarColor implements Property {
+
+    public static boolean describes(ObjectTag entity) {
+        return entity instanceof EntityTag && (
+                ((EntityTag) entity).getBukkitEntityType() == EntityType.WOLF
+                || ((EntityTag) entity).getBukkitEntityType() == EntityType.CAT);
+    }
+
+    public static EntityCollarColor getFrom(ObjectTag entity) {
+        if (!describes(entity)) {
+            return null;
+        }
+        return new EntityCollarColor((EntityTag) entity);
+    }
+
+    public static final String[] handledTags = new String[] {
+            "collar_color"
+    };
+
+    public static final String[] handledMechs = new String[] {
+            "collar_color"
+    };
+
+
+    ///////////////////
+    // Instance Fields and Methods
+    /////////////
+
+    private EntityCollarColor(EntityTag entity) {
+        this.entity = entity;
+    }
+
+    private EntityTag entity;
+
+    // If it's not a wolf, it's a cat!
+    private boolean isWolf() {
+        return entity.getBukkitEntityType() == EntityType.WOLF;
+    }
+
+    private String getCollarColor() {
+        if (isWolf()) {
+            return ((Wolf) entity.getBukkitEntity()).getCollarColor().name();
+        }
+        return ((Cat) entity.getBukkitEntity()).getCollarColor().name();
+    }
+
+    /////////
+    // Property Methods
+    ///////
+
+    @Override
+    public String getPropertyString() {
+        return getCollarColor();
+    }
+
+    @Override
+    public String getPropertyId() {
+        return "collar_color";
+    }
+
+    ///////////
+    // ObjectTag Attributes
+    ////////
+
+    @Override
+    public String getAttribute(Attribute attribute) {
+        if (attribute == null) {
+            return null;
+        }
+
+        // <--[tag]
+        // @attribute <EntityTag.collar_color>
+        // @returns ElementTag
+        // @mechanism EntityTag.collar_color
+        // @group properties
+        // @description
+        // If the entity is a wolf or cat, returns the color of its collar.
+        // Can be one of: <>
+        // -->
+        if (attribute.startsWith("collar_color")) {
+            return new ElementTag(getCollarColor()).getAttribute(attribute.fulfill(1));
+        }
+
+        return null;
+    }
+
+    @Override
+    public void adjust(Mechanism mechanism) {
+
+        // <--[mechanism]
+        // @object EntityTag
+        // @name collar_color
+        // @input ElementTag
+        // @description
+        // If the entity is a wolf or cat, sets the color of its collar.
+        // Valid colors are: <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/DyeColor.html>
+        // @tags
+        // <EntityTag.collar_color>
+        // -->
+        if (mechanism.matches("collar_color") && mechanism.requireEnum(false, DyeColor.values())) {
+            DyeColor color = DyeColor.valueOf(mechanism.getValue().asString().toUpperCase());
+            if (isWolf()) {
+                ((Wolf) entity.getBukkitEntity()).setCollarColor(color);
+            }
+            else {
+                ((Cat) entity.getBukkitEntity()).setCollarColor(color);
+            }
+        }
+    }
+}

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityFoxCrouching.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityFoxCrouching.java
@@ -47,7 +47,7 @@ public class EntityFoxCrouching implements Property {
 
     @Override
     public String getPropertyString() {
-        return ((Fox) entity.getBukkitEntity()).isCrouching() ? "true" : null;
+        return String.valueOf(((Fox) entity.getBukkitEntity()).isCrouching());
     }
 
     @Override

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityFoxCrouching.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityFoxCrouching.java
@@ -1,0 +1,99 @@
+package com.denizenscript.denizen.objects.properties.entity;
+
+import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.objects.properties.Property;
+import com.denizenscript.denizencore.tags.Attribute;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Fox;
+
+public class EntityFoxCrouching implements Property {
+
+    public static boolean describes(ObjectTag entity) {
+        return entity instanceof EntityTag && ((EntityTag) entity).getBukkitEntityType() == EntityType.FOX;
+    }
+
+    public static EntityFoxCrouching getFrom(ObjectTag entity) {
+        if (!describes(entity)) {
+            return null;
+        }
+        return new EntityFoxCrouching((EntityTag) entity);
+    }
+
+    public static final String[] handledTags = new String[] {
+            "crouching"
+    };
+
+    public static final String[] handledMechs = new String[] {
+            "crouching"
+    };
+
+
+    ///////////////////
+    // Instance Fields and Methods
+    /////////////
+
+    private EntityFoxCrouching(EntityTag entity) {
+        this.entity = entity;
+    }
+
+    private EntityTag entity;
+
+    /////////
+    // Property Methods
+    ///////
+
+    @Override
+    public String getPropertyString() {
+        return ((Fox) entity.getBukkitEntity()).isCrouching() ? "true" : null;
+    }
+
+    @Override
+    public String getPropertyId() {
+        return "crouching";
+    }
+
+    ///////////
+    // ObjectTag Attributes
+    ////////
+
+    @Override
+    public String getAttribute(Attribute attribute) {
+        if (attribute == null) {
+            return null;
+        }
+
+        // <--[tag]
+        // @attribute <EntityTag.crouching>
+        // @returns ElementTag(Boolean)
+        // @mechanism EntityTag.crouching
+        // @group properties
+        // @description
+        // If the entity is a fox, returns whether the entity is crouching.
+        // -->
+        if (attribute.startsWith("crouching")) {
+            return new ElementTag(((Fox) entity.getBukkitEntity()).isCrouching()).getAttribute(attribute.fulfill(1));
+        }
+
+        return null;
+    }
+
+    @Override
+    public void adjust(Mechanism mechanism) {
+
+        // <--[mechanism]
+        // @object EntityTag
+        // @name crouching
+        // @input ElementTag(Boolean)
+        // @description
+        // If the entity is a fox, sets whether the fox is crouching.
+        // @tags
+        // <EntityTag.crouching>
+        // -->
+        if (mechanism.matches("crouching") && mechanism.requireBoolean()) {
+            ((Fox) entity.getBukkitEntity()).setCrouching(mechanism.getValue().asBoolean());
+        }
+    }
+}

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityFoxType.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityFoxType.java
@@ -47,7 +47,7 @@ public class EntityFoxType implements Property {
 
     @Override
     public String getPropertyString() {
-        return ((Fox) entity.getBukkitEntity()).getFoxType() != Fox.Type.RED ? ((Fox) entity.getBukkitEntity()).getFoxType().name() : null;
+        return ((Fox) entity.getBukkitEntity()).getFoxType().name();
     }
 
     @Override

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityFoxType.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityFoxType.java
@@ -1,0 +1,101 @@
+package com.denizenscript.denizen.objects.properties.entity;
+
+import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.objects.properties.Property;
+import com.denizenscript.denizencore.tags.Attribute;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Fox;
+
+public class EntityFoxType implements Property {
+
+    public static boolean describes(ObjectTag entity) {
+        return entity instanceof EntityTag && ((EntityTag) entity).getBukkitEntityType() == EntityType.FOX;
+    }
+
+    public static EntityFoxType getFrom(ObjectTag entity) {
+        if (!describes(entity)) {
+            return null;
+        }
+        return new EntityFoxType((EntityTag) entity);
+    }
+
+    public static final String[] handledTags = new String[] {
+            "fox_type"
+    };
+
+    public static final String[] handledMechs = new String[] {
+            "fox_type"
+    };
+
+
+    ///////////////////
+    // Instance Fields and Methods
+    /////////////
+
+    private EntityFoxType(EntityTag entity) {
+        this.entity = entity;
+    }
+
+    private EntityTag entity;
+
+    /////////
+    // Property Methods
+    ///////
+
+    @Override
+    public String getPropertyString() {
+        return ((Fox) entity.getBukkitEntity()).getFoxType() != Fox.Type.RED ? ((Fox) entity.getBukkitEntity()).getFoxType().name() : null;
+    }
+
+    @Override
+    public String getPropertyId() {
+        return "fox_type";
+    }
+
+    ///////////
+    // ObjectTag Attributes
+    ////////
+
+    @Override
+    public String getAttribute(Attribute attribute) {
+        if (attribute == null) {
+            return null;
+        }
+
+        // <--[tag]
+        // @attribute <EntityTag.fox_type>
+        // @returns ElementTag
+        // @mechanism EntityTag.fox_type
+        // @group properties
+        // @description
+        // If the entity is a fox, return its type.
+        // Can be either RED or SNOW.
+        // -->
+        if (attribute.startsWith("fox_type")) {
+            return new ElementTag(((Fox) entity.getBukkitEntity()).getFoxType().name()).getAttribute(attribute.fulfill(1));
+        }
+
+        return null;
+    }
+
+    @Override
+    public void adjust(Mechanism mechanism) {
+
+        // <--[mechanism]
+        // @object EntityTag
+        // @name fox_type
+        // @input ElementTag
+        // @description
+        // Sets the fox entity's fox type.
+        // Can be either RED or SNOW.
+        // @tags
+        // <EntityTag.fox_type>
+        // -->
+        if (mechanism.matches("fox_type") && mechanism.requireEnum(false, Fox.Type.values())) {
+            ((Fox) entity.getBukkitEntity()).setFoxType(Fox.Type.valueOf(mechanism.getValue().asString().toUpperCase()));
+        }
+    }
+}

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityMooshroomVariant.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityMooshroomVariant.java
@@ -1,0 +1,100 @@
+package com.denizenscript.denizen.objects.properties.entity;
+
+import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.objects.properties.Property;
+import com.denizenscript.denizencore.tags.Attribute;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.MushroomCow;
+
+public class EntityMooshroomVariant implements Property {
+
+    public static boolean describes(ObjectTag entity) {
+        return entity instanceof EntityTag && ((EntityTag) entity).getBukkitEntityType() == EntityType.MUSHROOM_COW;
+    }
+
+    public static EntityMooshroomVariant getFrom(ObjectTag entity) {
+        if (!describes(entity)) {
+            return null;
+        }
+        return new EntityMooshroomVariant((EntityTag) entity);
+    }
+
+    public static final String[] handledTags = new String[] {
+            "mooshroom_variant"
+    };
+
+    public static final String[] handledMechs = new String[] {
+            "mooshroom_variant"
+    };
+
+
+    ///////////////////
+    // Instance Fields and Methods
+    /////////////
+
+    private EntityMooshroomVariant(EntityTag entity) {
+        this.entity = entity;
+    }
+
+    private EntityTag entity;
+
+    /////////
+    // Property Methods
+    ///////
+
+    @Override
+    public String getPropertyString() {
+        return ((MushroomCow) entity.getBukkitEntity()).getVariant() != MushroomCow.Variant.RED ? ((MushroomCow) entity.getBukkitEntity()).getVariant().name() : null;
+    }
+
+    @Override
+    public String getPropertyId() {
+        return "mooshroom_variant";
+    }
+
+    ///////////
+    // ObjectTag Attributes
+    ////////
+
+    @Override
+    public String getAttribute(Attribute attribute) {
+        if (attribute == null) {
+            return null;
+        }
+
+        // <--[tag]
+        // @attribute <EntityTag.mooshroom_variant>
+        // @returns ElementTag
+        // @mechanism EntityTag.mooshroom_variant
+        // @group properties
+        // @description
+        // If the entity is a mooshroom cow, returns the variant of the entity.
+        // Can be either RED or BROWN.
+        // -->
+        if (attribute.startsWith("mooshroom_variant")) {
+            return new ElementTag(((MushroomCow) entity.getBukkitEntity()).getVariant().name()).getAttribute(attribute.fulfill(1));
+        }
+
+        return null;
+    }
+
+    @Override
+    public void adjust(Mechanism mechanism) {
+
+        // <--[mechanism]
+        // @object EntityTag
+        // @name mooshroom_variant
+        // @input ElementTag
+        // @description
+        // Sets the mooshroom cow entity's color variation. Can be either RED or BROWN.
+        // @tags
+        // <EntityTag.mooshroom_variant>
+        // -->
+        if (mechanism.matches("mooshroom_variant") && mechanism.requireEnum(false, MushroomCow.Variant.values())) {
+            ((MushroomCow) entity.getBukkitEntity()).setVariant(MushroomCow.Variant.valueOf(mechanism.getValue().asString().toUpperCase()));
+        }
+    }
+}

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityMooshroomVariant.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityMooshroomVariant.java
@@ -47,7 +47,7 @@ public class EntityMooshroomVariant implements Property {
 
     @Override
     public String getPropertyString() {
-        return ((MushroomCow) entity.getBukkitEntity()).getVariant() != MushroomCow.Variant.RED ? ((MushroomCow) entity.getBukkitEntity()).getVariant().name() : null;
+        return ((MushroomCow) entity.getBukkitEntity()).getVariant().name();
     }
 
     @Override

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityPandaGene.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityPandaGene.java
@@ -8,6 +8,7 @@ import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.core.ListTag;
 import com.denizenscript.denizencore.objects.properties.Property;
 import com.denizenscript.denizencore.tags.Attribute;
+import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Panda;
 
 import java.util.ArrayList;
@@ -16,14 +17,14 @@ import java.util.List;
 public class EntityPandaGene implements Property {
 
     public static boolean describes(ObjectTag entity) {
-        return false;
+        return entity instanceof EntityTag && ((EntityTag) entity).getBukkitEntityType() == EntityType.PANDA;
     }
 
     public static EntityPandaGene getFrom(ObjectTag entity) {
         if (!describes(entity)) {
             return null;
         }
-        return null;
+        return new EntityPandaGene((EntityTag) entity);
     }
 
     public static final String[] handledTags = new String[] {
@@ -111,7 +112,7 @@ public class EntityPandaGene implements Property {
         // If the entity is a panda, returns both the main and hidden genes in this order: MAIN|HIDDEN.
         // The genes can be any of: <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/entity/Panda.Gene.html>
         // -->
-        if (attribute.startsWith("hidden_gene")) {
+        if (attribute.startsWith("genes")) {
             ListTag list = new ListTag();
             return new ListTag(getGenes()).getAttribute(attribute.fulfill(1));
         }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityPandaGene.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityPandaGene.java
@@ -173,9 +173,20 @@ public class EntityPandaGene implements Property {
                 return;
             }
 
+            Panda.Gene mainGene;
+            Panda.Gene hiddenGene;
+            try {
+                mainGene = Panda.Gene.valueOf(filteredList.get(0).toUpperCase());
+                hiddenGene = Panda.Gene.valueOf(filteredList.get(1).toUpperCase());
+            }
+            catch (IllegalArgumentException e) {
+                Debug.echoError("Invalid gene(s) were specified!");
+                return;
+            }
+
             Panda panda = (Panda) entity.getBukkitEntity();
-            panda.setMainGene(Panda.Gene.valueOf(filteredList.get(1).toUpperCase()));
-            panda.setHiddenGene(Panda.Gene.valueOf(filteredList.get(1).toUpperCase()));
+            panda.setMainGene(mainGene);
+            panda.setHiddenGene(hiddenGene);
         }
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityPandaGene.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityPandaGene.java
@@ -1,0 +1,180 @@
+package com.denizenscript.denizen.objects.properties.entity;
+
+import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizen.utilities.debugging.Debug;
+import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.objects.core.ListTag;
+import com.denizenscript.denizencore.objects.properties.Property;
+import com.denizenscript.denizencore.tags.Attribute;
+import org.bukkit.entity.Panda;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class EntityPandaGene implements Property {
+
+    public static boolean describes(ObjectTag entity) {
+        return false;
+    }
+
+    public static EntityPandaGene getFrom(ObjectTag entity) {
+        if (!describes(entity)) {
+            return null;
+        }
+        return null;
+    }
+
+    public static final String[] handledTags = new String[] {
+            "genes", "main_gene", "hidden_gene"
+    };
+
+    public static final String[] handledMechs = new String[] {
+            "genes", "main_gene", "hidden_gene"
+    };
+
+
+    ///////////////////
+    // Instance Fields and Methods
+    /////////////
+
+    private EntityPandaGene(EntityTag entity) {
+        this.entity = entity;
+    }
+
+    private EntityTag entity;
+
+    private List<String> getGenes() {
+        List<String> list = new ArrayList<>();
+        Panda panda = (Panda) entity.getBukkitEntity();
+        list.add(panda.getMainGene().name());
+        list.add(panda.getHiddenGene().name());
+        return list;
+    }
+
+    /////////
+    // Property Methods
+    ///////
+
+    @Override
+    public String getPropertyString() {
+        return new ListTag(getGenes()).identify();
+    }
+
+    @Override
+    public String getPropertyId() {
+        return "genes";
+    }
+
+    ///////////
+    // ObjectTag Attributes
+    ////////
+
+    @Override
+    public String getAttribute(Attribute attribute) {
+        if (attribute == null) {
+            return null;
+        }
+
+        // <--[tag]
+        // @attribute <EntityTag.main_gene>
+        // @returns ElementTag
+        // @mechanism EntityTag.main_gene
+        // @group properties
+        // @description
+        // If the entity is a panda, returns the main gene.
+        // The gene can be any of: <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/entity/Panda.Gene.html>
+        // -->
+        if (attribute.startsWith("main_gene")) {
+            return new ElementTag(((Panda) entity.getBukkitEntity()).getMainGene().name()).getAttribute(attribute.fulfill(1));
+        }
+
+        // <--[tag]
+        // @attribute <EntityTag.hidden_gene>
+        // @returns ElementTag
+        // @mechanism EntityTag.hidden_gene
+        // @group properties
+        // @description
+        // If the entity is a panda, returns the hidden gene.
+        // The gene can be any of: <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/entity/Panda.Gene.html>
+        // -->
+        if (attribute.startsWith("hidden_gene")) {
+            return new ElementTag(((Panda) entity.getBukkitEntity()).getHiddenGene().name()).getAttribute(attribute.fulfill(1));
+        }
+
+        // <--[tag]
+        // @attribute <EntityTag.genes>
+        // @returns ListTag
+        // @group properties
+        // @description
+        // If the entity is a panda, returns both the main and hidden genes in this order: MAIN|HIDDEN.
+        // The genes can be any of: <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/entity/Panda.Gene.html>
+        // -->
+        if (attribute.startsWith("hidden_gene")) {
+            ListTag list = new ListTag();
+            return new ListTag(getGenes()).getAttribute(attribute.fulfill(1));
+        }
+
+        return null;
+    }
+
+    @Override
+    public void adjust(Mechanism mechanism) {
+
+        // <--[mechanism]
+        // @object EntityTag
+        // @name main_gene
+        // @input ElementTag
+        // @description
+        // If the entity is a panda, sets the entity's main gene.
+        // @tags
+        // <EntityTag.genes>
+        // <EntityTag.main_gene>
+        // <EntityTag.hidden_gene>
+        // -->
+        if (mechanism.matches("main_gene") && mechanism.requireEnum(false, Panda.Gene.values())) {
+            ((Panda) entity.getBukkitEntity()).setMainGene(Panda.Gene.valueOf(mechanism.getValue().asString().toUpperCase()));
+        }
+
+        // <--[mechanism]
+        // @object EntityTag
+        // @name hidden_gene
+        // @input ElementTag
+        // @description
+        // If the entity is a panda, sets the entity's hidden gene.
+        // @tags
+        // <EntityTag.genes>
+        // <EntityTag.main_gene>
+        // <EntityTag.hidden_gene>
+        // -->
+        if (mechanism.matches("hidden_gene") && mechanism.requireEnum(false, Panda.Gene.values())) {
+            ((Panda) entity.getBukkitEntity()).setHiddenGene(Panda.Gene.valueOf(mechanism.getValue().asString().toUpperCase()));
+        }
+
+        // <--[mechanism]
+        // @object EntityTag
+        // @name genes
+        // @input ListTag
+        // @description
+        // If the entity is a panda, sets the entity's main and hidden gene.
+        // Input should be formatted as MAIN_GENE|HIDDEN_GENE.
+        // @tags
+        // <EntityTag.genes>
+        // <EntityTag.main_gene>
+        // <EntityTag.hidden_gene>
+        // -->
+        if (mechanism.matches("genes") && mechanism.requireObject(ListTag.class)) {
+            ListTag list = mechanism.valueAsType(ListTag.class);
+            List<String> filteredList = list.filter(Panda.Gene.values());
+            if (filteredList == null || filteredList.size() != 2) {
+                Debug.echoError("Gene list must contain only valid genes and be exactly two items long!");
+                return;
+            }
+
+            Panda panda = (Panda) entity.getBukkitEntity();
+            panda.setMainGene(Panda.Gene.valueOf(filteredList.get(1).toUpperCase()));
+            panda.setHiddenGene(Panda.Gene.valueOf(filteredList.get(1).toUpperCase()));
+        }
+    }
+}

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityPatrolLeader.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityPatrolLeader.java
@@ -1,0 +1,100 @@
+package com.denizenscript.denizen.objects.properties.entity;
+
+import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.objects.properties.Property;
+import com.denizenscript.denizencore.tags.Attribute;
+import org.bukkit.entity.Raider;
+
+public class EntityPatrolLeader implements Property {
+
+    public static boolean describes(ObjectTag entity) {
+        return entity instanceof EntityTag && ((EntityTag) entity).getBukkitEntity() instanceof Raider;
+    }
+
+    public static EntityPatrolLeader getFrom(ObjectTag entity) {
+        if (!describes(entity)) {
+            return null;
+        }
+        return new EntityPatrolLeader((EntityTag) entity);
+    }
+
+    public static final String[] handledTags = new String[] {
+            "is_patrol_leader"
+    };
+
+    public static final String[] handledMechs = new String[] {
+            "is_patrol_leader"
+    };
+
+
+    ///////////////////
+    // Instance Fields and Methods
+    /////////////
+
+    private EntityPatrolLeader(EntityTag entity) {
+        this.entity = entity;
+    }
+
+    private EntityTag entity;
+
+    /////////
+    // Property Methods
+    ///////
+
+
+    @Override
+    public String getPropertyString() {
+        return ((Raider) entity.getBukkitEntity()).isPatrolLeader() ? "true" : null;
+    }
+
+    @Override
+    public String getPropertyId() {
+        return "is_patrol_leader";
+    }
+
+    ///////////
+    // ObjectTag Attributes
+    ////////
+
+
+    @Override
+    public String getAttribute(Attribute attribute) {
+        if (attribute == null) {
+            return null;
+        }
+
+        // <--[tag]
+        // @attribute <EntityTag.is_patrol_leader>
+        // @returns ElementTag(Boolean)
+        // @mechanism EntityTag.is_patrol_leader
+        // @group properties
+        // @description
+        // If the entity is a raider, returns whether this entity is a patrol leader.
+        // -->
+        if (attribute.startsWith("is_patrol_leader")) {
+            return new ElementTag(((Raider) entity.getBukkitEntity()).isPatrolLeader()).getAttribute(attribute.fulfill(1));
+        }
+
+        return null;
+    }
+
+    @Override
+    public void adjust(Mechanism mechanism) {
+
+        // <--[mechanism]
+        // @object EntityTag
+        // @name is_patrol_leader
+        // @input ElementTag(Boolean)
+        // @description
+        // If the entity is a raider, set whether this entity is a patrol leader.
+        // @tags
+        // <EntityTag.is_patrol_leader>
+        // -->
+        if (mechanism.matches("is_patrol_leader") && mechanism.requireBoolean()) {
+            ((Raider) entity.getBukkitEntity()).setPatrolLeader(mechanism.getValue().asBoolean());
+        }
+    }
+}

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityPatrolLeader.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityPatrolLeader.java
@@ -47,7 +47,7 @@ public class EntityPatrolLeader implements Property {
 
     @Override
     public String getPropertyString() {
-        return ((Raider) entity.getBukkitEntity()).isPatrolLeader() ? "true" : null;
+        return String.valueOf(((Raider) entity.getBukkitEntity()).isPatrolLeader());
     }
 
     @Override

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityPatrolTarget.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityPatrolTarget.java
@@ -1,0 +1,107 @@
+package com.denizenscript.denizen.objects.properties.entity;
+
+import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizen.objects.LocationTag;
+import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.properties.Property;
+import com.denizenscript.denizencore.tags.Attribute;
+import org.bukkit.entity.Raider;
+
+public class EntityPatrolTarget implements Property {
+
+    public static boolean describes(ObjectTag entity) {
+        return entity instanceof EntityTag && ((EntityTag) entity).getBukkitEntity() instanceof Raider;
+    }
+
+    public static EntityPatrolTarget getFrom(ObjectTag entity) {
+        if (!describes(entity)) {
+            return null;
+        }
+        return new EntityPatrolTarget((EntityTag) entity);
+    }
+
+    public static final String[] handledTags = new String[] {
+            "patrol_target"
+    };
+
+    public static final String[] handledMechs = new String[] {
+            "patrol_target"
+    };
+
+
+    ///////////////////
+    // Instance Fields and Methods
+    /////////////
+
+    private EntityPatrolTarget(EntityTag entity) {
+        this.entity = entity;
+    }
+
+    private EntityTag entity;
+
+    /////////
+    // Property Methods
+    ///////
+
+    @Override
+    public String getPropertyString() {
+        return new LocationTag(((Raider) entity.getBukkitEntity()).getPatrolTarget().getLocation()).identify();
+    }
+
+    @Override
+    public String getPropertyId() {
+        return "patrol_target";
+    }
+
+    ///////////
+    // ObjectTag Attributes
+    ////////
+
+    @Override
+    public String getAttribute(Attribute attribute) {
+        if (attribute == null) {
+            return null;
+        }
+
+        // <--[tag]
+        // @attribute <EntityTag.patrol_target>
+        // @returns LocationTag
+        // @mechanism EntityTag.patrol_target
+        // @group properties
+        // @description
+        // If the entity is a raider, returns the location the raider is targeting to patrol.
+        // -->
+        if (attribute.startsWith("patrol_target")) {
+            return new LocationTag(((Raider) entity.getBukkitEntity()).getPatrolTarget().getLocation()).getAttribute(attribute.fulfill(1));
+        }
+
+        return null;
+    }
+
+    @Override
+    public void adjust(Mechanism mechanism) {
+
+        // <--[mechanism]
+        // @object EntityTag
+        // @name patrol_target
+        // @input LocationTag
+        // @description
+        // If the entity is a raider, sets the location the raider will target to patrol.
+        // Provide no input to set no target.
+        // @tags
+        // <EntityTag.patrol_target>
+        // -->
+        if (mechanism.matches("patrol_target")) {
+            Raider raider = (Raider) entity.getBukkitEntity();
+            if (!mechanism.hasValue()) {
+                raider.setPatrolTarget(null);
+            }
+            else {
+                if (mechanism.requireObject(LocationTag.class)) {
+                    raider.setPatrolTarget(mechanism.valueAsType(LocationTag.class).getBlock());
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds multiple 1.14-specific tags/mecs for entities. Specifically:
- cat types
- cat/wolf collar color
- vex charging state
- fox crouching
- fox type
- mooshroom variants
- panda genes
- pillager patrol leader status
- pillager patrol location target

Fixes #7 (vex-related issue)