### PR TITLE
Add all Spigot BlockData interfaces as MaterialTag properties

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/objects/MaterialTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/MaterialTag.java
@@ -531,7 +531,7 @@ public class MaterialTag implements ObjectTag, Adjustable {
         // When this returns true, <@link tag MaterialTag.direction>, <@link tag MaterialTag.valid_directions>,
         // and <@link mechanism MaterialTag.direction> are accessible.
         // -->
-        registerTag("is_bisected", new TagRunnable() {
+        registerTag("is_directional", new TagRunnable() {
             @Override
             public String run(Attribute attribute, ObjectTag object) {
                 return new ElementTag(MaterialHalf.describes(object))

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/MaterialTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/MaterialTag.java
@@ -1,9 +1,6 @@
 package com.denizenscript.denizen.objects;
 
-import com.denizenscript.denizen.objects.properties.material.MaterialAge;
-import com.denizenscript.denizen.objects.properties.material.MaterialHalf;
-import com.denizenscript.denizen.objects.properties.material.MaterialLevel;
-import com.denizenscript.denizen.objects.properties.material.MaterialLightable;
+import com.denizenscript.denizen.objects.properties.material.*;
 import com.denizenscript.denizen.utilities.blocks.OldMaterialsHelper;
 import com.denizenscript.denizen.utilities.debugging.Debug;
 import com.denizenscript.denizencore.objects.*;
@@ -509,6 +506,23 @@ public class MaterialTag implements ObjectTag, Adjustable {
         });
 
         // <--[tag]
+        // @attribute <MaterialTag.is_attachable>
+        // @returns ElementTag(Boolean)
+        // @group properties
+        // @description
+        // Returns whether the material is an attachable material (tripwire hooks and strings).
+        // When this returns true, <@link tag MaterialTag.is_attached>
+        // and <@link mechanism MaterialTag.is_attached> are accessible.
+        // -->
+        registerTag("is_attachable", new TagRunnable() {
+            @Override
+            public String run(Attribute attribute, ObjectTag objectTag) {
+                return new ElementTag(MaterialAttached.describes(objectTag))
+                        .getAttribute(attribute.fulfill(1));
+            }
+        });
+
+        // <--[tag]
         // @attribute <MaterialTag.is_directional>
         // @returns ElementTag(Boolean)
         // @group properties
@@ -572,6 +586,158 @@ public class MaterialTag implements ObjectTag, Adjustable {
             @Override
             public String run(Attribute attribute, ObjectTag object) {
                 return new ElementTag(MaterialLightable.describes(object))
+                        .getAttribute(attribute.fulfill(1));
+            }
+        });
+
+        // <--[tag]
+        // @attribute <MaterialTag.is_multifacing>
+        // @returns ElementTag(Boolean)
+        // @group properties
+        // @description
+        // Returns whether the material can have multiple faces.
+        // When this returns true, <@link tag MaterialTag.faces>, <@link tag MaterialTag.has_face[<face>]>,
+        // <@link tag MaterialTag.allowed_faces>, and <@link mechanism MaterialTag.faces> are accessible.
+        // -->
+        registerTag("is_multifacing", new TagRunnable() {
+            @Override
+            public String run(Attribute attribute, ObjectTag objectTag) {
+                return new ElementTag(MaterialMultipleFacing.describes(objectTag))
+                        .getAttribute(attribute.fulfill(1));
+            }
+        });
+
+        // <--[tag]
+        // @attribute <MaterialTag.is_openable>
+        // @returns ElementTag(Boolean)
+        // @group properties
+        // @description
+        // Returns whether the material can be opened (for example, doors).
+        // When this returns true, <@link tag MaterialTag.is_open>
+        // and <@link mechanism MaterialTag.is_open> are accessible.
+        // -->
+        registerTag("is_openable", new TagRunnable() {
+            @Override
+            public String run(Attribute attribute, ObjectTag objectTag) {
+                return new ElementTag(MaterialOpen.describes(objectTag))
+                        .getAttribute(attribute.fulfill(1));
+            }
+        });
+
+        // <--[tag]
+        // @attribute <MaterialTag.is_orientable>
+        // @returns ElementTag(Boolean)
+        // @group properties
+        // @description
+        // Returns whether the material is orientable (for example, oak logs).
+        // When this returns true, <@link tag MaterialTag.valid_orientations>, <@link tag MaterialTag.orientation>,
+        // and <@link mechanism MaterialTag.orientation> are accessible.
+        // -->
+        registerTag("is_orientable", new TagRunnable() {
+            @Override
+            public String run(Attribute attribute, ObjectTag objectTag) {
+                return new ElementTag(MaterialOrientation.describes(objectTag))
+                        .getAttribute(attribute.fulfill(1));
+            }
+        });
+
+        // <--[tag]
+        // @attribute <MaterialTag.is_rail>
+        // @returns ElementTag(Boolean)
+        // @group properties
+        // @description
+        // Returns whether the material is a rail.
+        // When this returns true, <@link tag MaterialTag.valid_rail_shapes>, <@link tag MaterialTag.rail_shape>,
+        // and <@link mechanism MaterialTag.rail_shape> are accessible.
+        // -->
+        registerTag("is_rail", new TagRunnable() {
+            @Override
+            public String run(Attribute attribute, ObjectTag objectTag) {
+                return new ElementTag(MaterialRailShape.describes(objectTag))
+                        .getAttribute(attribute.fulfill(1));
+            }
+        });
+
+        // <--[tag]
+        // @attribute <MaterialTag.is_redstone_powerable>
+        // @returns ElementTag(Boolean)
+        // @group properties
+        // @description
+        // Returns whether the material is a redstone power source or can be powered by redstone.
+        // When this returns true, <@link tag MaterialTag.redstone_power>, <@link tag MaterialTag.max_redstone_power>,
+        // and <@link mechanism MaterialTag.redstone_power> are accessible.
+        // -->
+        registerTag("is_redstone_powerable", new TagRunnable() {
+            @Override
+            public String run(Attribute attribute, ObjectTag objectTag) {
+                return new ElementTag(MaterialRedstonePower.describes(objectTag))
+                        .getAttribute(attribute.fulfill(1));
+            }
+        });
+
+        // <--[tag]
+        // @attribute <MaterialTag.is_rotatable>
+        // @returns ElementTag(Boolean)
+        // @group properties
+        // @description
+        // Returns whether the material is rotatable (for example, player heads).
+        // When this returns true, <@link tag MaterialTag.rotation>,
+        // and <@link mechanism MaterialTag.rotation> are accessible.
+        // -->
+        registerTag("is_rotatable", new TagRunnable() {
+            @Override
+            public String run(Attribute attribute, ObjectTag objectTag) {
+                return new ElementTag(MaterialRotation.describes(objectTag))
+                        .getAttribute(attribute.fulfill(1));
+            }
+        });
+
+        // <--[tag]
+        // @attribute <MaterialTag.is_snowable>
+        // @returns ElementTag(Boolean)
+        // @group properties
+        // @description
+        // Returns whether the material is snowable (for example, grass blocks).
+        // When this returns true, <@link tag MaterialTag.snowy>
+        // and <@link mechanism MaterialTag.snowy> are accessible.
+        // -->
+        registerTag("is_snowable", new TagRunnable() {
+            @Override
+            public String run(Attribute attribute, ObjectTag objectTag) {
+                return new ElementTag(MaterialOrientation.describes(objectTag))
+                        .getAttribute(attribute.fulfill(1));
+            }
+        });
+
+        // <--[tag]
+        // @attribute <MaterialTag.is_switch>
+        // @returns ElementTag(Boolean)
+        // @group properties
+        // @description
+        // Returns whether the material is a switch (button or lever).
+        // When this is true, <@link tag MaterialTag.switch_face>
+        // and <@link mechanism MaterialTag.switch_face> are accessible.
+        registerTag("is_switch", new TagRunnable() {
+            @Override
+            public String run(Attribute attribute, ObjectTag objectTag) {
+                return new ElementTag(MaterialSwitchFace.describes(objectTag))
+                        .getAttribute(attribute.fulfill(1));
+            }
+        });
+
+        // <--[tag]
+        // @attribute <MaterialTag.is_waterloggable>
+        // @returns ElementTag(Boolean)
+        // @group properties
+        // @description
+        // Returns whether the material is waterloggable.
+        // When this returns true, <@link tag MaterialTag.waterlogged>
+        // and <@link mechanism MaterialTag.waterlogged> are accessible.
+        // -->
+        registerTag("is_waterloggable", new TagRunnable() {
+            @Override
+            public String run(Attribute attribute, ObjectTag objectTag) {
+                return new ElementTag(MaterialWaterlogged.describes(objectTag))
                         .getAttribute(attribute.fulfill(1));
             }
         });

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/MaterialTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/MaterialTag.java
@@ -666,6 +666,7 @@ public class MaterialTag implements ObjectTag, Adjustable {
         // Returns whether the material is a redstone power source or can be powered by redstone.
         // When this returns true, <@link tag MaterialTag.redstone_power>, <@link tag MaterialTag.max_redstone_power>,
         // and <@link mechanism MaterialTag.redstone_power> are accessible.
+        // NOTE: This returns true only for daylight detectors and redstone wires.
         // -->
         registerTag("is_redstone_powerable", new TagRunnable() {
             @Override
@@ -683,6 +684,7 @@ public class MaterialTag implements ObjectTag, Adjustable {
         // Returns whether the material is rotatable (for example, player heads).
         // When this returns true, <@link tag MaterialTag.rotation>,
         // and <@link mechanism MaterialTag.rotation> are accessible.
+        // NOTE: This returns true only for standing signs (not wall signs).
         // -->
         registerTag("is_rotatable", new TagRunnable() {
             @Override

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/MaterialTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/MaterialTag.java
@@ -527,7 +527,7 @@ public class MaterialTag implements ObjectTag, Adjustable {
         // @returns ElementTag(Boolean)
         // @group properties
         // @description
-        // Returns whether the material is a is_directional material.
+        // Returns whether the material is a directional material.
         // When this returns true, <@link tag MaterialTag.direction>, <@link tag MaterialTag.valid_directions>,
         // and <@link mechanism MaterialTag.direction> are accessible.
         // -->

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
@@ -133,11 +133,20 @@ public class PropertyRegistry {
         // register core MaterialTag properties
         if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_13)) {
             PropertyParser.registerProperty(MaterialAge.class, MaterialTag.class);
+            PropertyParser.registerProperty(MaterialAttached.class, MaterialTag.class);
             PropertyParser.registerProperty(MaterialDirectional.class, MaterialTag.class);
             PropertyParser.registerProperty(MaterialHalf.class, MaterialTag.class);
             PropertyParser.registerProperty(MaterialLevel.class, MaterialTag.class);
             PropertyParser.registerProperty(MaterialLightable.class, MaterialTag.class);
+            PropertyParser.registerProperty(MaterialMultipleFacing.class, MaterialTag.class);
+            PropertyParser.registerProperty(MaterialOpen.class, MaterialTag.class);
+            PropertyParser.registerProperty(MaterialOrientation.class, MaterialTag.class);
+            PropertyParser.registerProperty(MaterialRailShape.class, MaterialTag.class);
+            PropertyParser.registerProperty(MaterialRedstonePower.class, MaterialTag.class);
+            PropertyParser.registerProperty(MaterialRotation.class, MaterialTag.class);
+            PropertyParser.registerProperty(MaterialSnowy.class, MaterialTag.class);
             PropertyParser.registerProperty(MaterialSwitchFace.class, MaterialTag.class);
+            PropertyParser.registerProperty(MaterialWaterlogged.class, MaterialTag.class);
         }
 
         // register core TradeTag properties

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialAttached.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialAttached.java
@@ -24,11 +24,11 @@ public class MaterialAttached implements Property {
     }
 
     public static final String[] handledTags = new String[] {
-            "is_attached"
+            "attached"
     };
 
     public static final String[] handledMechs = new String[] {
-            "is_attached"
+            "attached"
     };
 
 
@@ -61,7 +61,7 @@ public class MaterialAttached implements Property {
 
     @Override
     public String getPropertyId() {
-        return "is_attached";
+        return "attached";
     }
 
     ///////////
@@ -75,14 +75,14 @@ public class MaterialAttached implements Property {
         }
 
         // <--[tag]
-        // @attribute <MaterialTag.is_attached>
+        // @attribute <MaterialTag.attached>
         // @returns ElementTag(Boolean)
-        // @mechanism MaterialTag.is_attached
+        // @mechanism MaterialTag.attached
         // @group properties
         // @description
         // If the material is a tripwire hook or string, returns if the material is part of a complete tripwire circuit.
         // -->
-        if (attribute.startsWith("is_attached")) {
+        if (attribute.startsWith("attached")) {
             return new ElementTag(isAttached()).getAttribute(attribute.fulfill(1));
         }
 
@@ -94,15 +94,15 @@ public class MaterialAttached implements Property {
 
         // <--[mechanism]
         // @object MaterialTag
-        // @name is_attached
+        // @name attached
         // @input ElementTag(Boolean)
         // @description
         // Sets the attached state of the material, if the material is a tripwire hook or a string.
         // NOTE: Updating the tripwire hook will visibly change the material's texture, while a string will not have any notable difference.
         // @tags
-        // <MaterialTag.is_attached>
+        // <MaterialTag.attached>
         // -->
-        if (mechanism.matches("is_attached") && mechanism.requireBoolean()) {
+        if (mechanism.matches("attached") && mechanism.requireBoolean()) {
             getAttachable().setAttached(mechanism.getValue().asBoolean());
         }
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialAttached.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialAttached.java
@@ -1,0 +1,109 @@
+package com.denizenscript.denizen.objects.properties.material;
+
+import com.denizenscript.denizen.objects.MaterialTag;
+import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.objects.properties.Property;
+import com.denizenscript.denizencore.tags.Attribute;
+import org.bukkit.block.data.Attachable;
+
+public class MaterialAttached implements Property {
+
+    public static boolean describes(ObjectTag material) {
+        return material instanceof MaterialTag
+                && ((MaterialTag) material).hasModernData()
+                && ((MaterialTag) material).getModernData().data instanceof Attachable;
+    }
+
+    public static MaterialAttached getFrom(ObjectTag material) {
+        if (!describes(material)) {
+            return null;
+        }
+        return new MaterialAttached((MaterialTag) material);
+    }
+
+    public static final String[] handledTags = new String[] {
+            "is_attached"
+    };
+
+    public static final String[] handledMechs = new String[] {
+            "is_attached"
+    };
+
+
+    ///////////////////
+    // Instance Fields and Methods
+    /////////////
+
+    private MaterialAttached(MaterialTag material) {
+        this.material = material;
+    }
+
+    private MaterialTag material;
+
+    private Attachable getAttachable() {
+        return (Attachable) material.getModernData().data;
+    }
+
+    private boolean isAttached() {
+        return getAttachable().isAttached();
+    }
+
+    /////////
+    // Property Methods
+    ///////
+
+    @Override
+    public String getPropertyString() {
+        return isAttached() ? "true" : null;
+    }
+
+    @Override
+    public String getPropertyId() {
+        return "is_attached";
+    }
+
+    ///////////
+    // ObjectTag Attributes
+    ////////
+
+    @Override
+    public String getAttribute(Attribute attribute) {
+        if (attribute == null) {
+            return null;
+        }
+
+        // <--[tag]
+        // @attribute <MaterialTag.is_attached>
+        // @returns ElementTag(Boolean)
+        // @mechanism MaterialTag.is_attached
+        // @group properties
+        // @description
+        // If the material is a tripwire hook or string, returns if the material is part of a complete tripwire circuit.
+        // -->
+        if (attribute.startsWith("is_attached")) {
+            return new ElementTag(isAttached()).getAttribute(attribute.fulfill(1));
+        }
+
+        return null;
+    }
+
+    @Override
+    public void adjust(Mechanism mechanism) {
+
+        // <--[mechanism]
+        // @object MaterialTag
+        // @name is_attached
+        // @input ElementTag(Boolean)
+        // @description
+        // Sets the attached state of the material, if the material is a tripwire hook or a string.
+        // NOTE: Updating the tripwire hook will visibly change the material's texture, while a string will not have any notable difference.
+        // @tags
+        // <MaterialTag.is_attached>
+        // -->
+        if (mechanism.matches("is_attached") && mechanism.requireBoolean()) {
+            getAttachable().setAttached(mechanism.getValue().asBoolean());
+        }
+    }
+}

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialLightable.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialLightable.java
@@ -68,7 +68,7 @@ public class MaterialLightable implements Property {
 
     @Override
     public String getPropertyString() {
-        return getLightable().isLit() ? "true" : "false";
+        return getLightable().isLit() ? "true" : null;
     }
 
     @Override

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialMultipleFacing.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialMultipleFacing.java
@@ -29,7 +29,7 @@ public class MaterialMultipleFacing implements Property {
     }
 
     public static final String[] handledTags = new String[] {
-            "allowed_faces", "has_face", "faces"
+            "valid_faces", "has_face", "faces"
     };
 
     public static final String[] handledMechs = new String[] {
@@ -84,14 +84,14 @@ public class MaterialMultipleFacing implements Property {
         }
 
         // <--[tag]
-        // @attribute <MaterialTag.allowed_faces>
+        // @attribute <MaterialTag.valid_faces>
         // @returns ListTag
         // @group properties
         // @description
         // If the material can have faces, returns which faces the material's texture can be displayed on.
         // A list of all faces can be found here: <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/block/BlockFace.html>
         // -->
-        if (attribute.startsWith("allowed_faces")) {
+        if (attribute.startsWith("valid_faces")) {
             ListTag allowedFaces = new ListTag();
             for (BlockFace face : getMultipleFacing().getAllowedFaces()) {
                 allowedFaces.add(face.name());
@@ -148,7 +148,7 @@ public class MaterialMultipleFacing implements Property {
         // A list of all faces can be found here: <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/block/BlockFace.html>
         // @tags
         // <MaterialTag.faces>
-        // <MaterialTag.allowed_faces>
+        // <MaterialTag.valid_faces>
         // <MaterialTag.has_face[<face>]>
         // -->
         if (mechanism.matches("faces")) {

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialMultipleFacing.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialMultipleFacing.java
@@ -151,7 +151,7 @@ public class MaterialMultipleFacing implements Property {
         // <MaterialTag.allowed_faces>
         // <MaterialTag.has_face[<face>]>
         // -->
-        if (mechanism.matches("faces") && mechanism.requireObject(ListTag.class)) {
+        if (mechanism.matches("faces")) {
             List<BlockFace> validFaces = new ArrayList<>();
             for (String input : mechanism.valueAsType(ListTag.class)) {
                 BlockFace face;

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialMultipleFacing.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialMultipleFacing.java
@@ -1,0 +1,181 @@
+package com.denizenscript.denizen.objects.properties.material;
+
+import com.denizenscript.denizen.objects.MaterialTag;
+import com.denizenscript.denizen.utilities.debugging.Debug;
+import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ListTag;
+import com.denizenscript.denizencore.objects.properties.Property;
+import com.denizenscript.denizencore.tags.Attribute;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.data.MultipleFacing;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MaterialMultipleFacing implements Property {
+
+    public static boolean describes(ObjectTag material) {
+        return material instanceof MaterialTag
+                && ((MaterialTag) material).hasModernData()
+                && ((MaterialTag) material).getModernData().data instanceof MultipleFacing;
+    }
+
+    public static MaterialMultipleFacing getFrom(ObjectTag material) {
+        if (!describes(material)) {
+            return null;
+        }
+        return new MaterialMultipleFacing((MaterialTag) material);
+    }
+
+    public static final String[] handledTags = new String[] {
+            "allowed_faces", "has_face", "faces"
+    };
+
+    public static final String[] handledMechs = new String[] {
+            "faces"
+    };
+
+
+    ///////////////////
+    // Instance Fields and Methods
+    /////////////
+
+    private MaterialMultipleFacing(MaterialTag material) {
+        this.material = material;
+    }
+
+    private MaterialTag material;
+
+    private MultipleFacing getMultipleFacing() {
+        return (MultipleFacing) material.getModernData().data;
+    }
+
+    private List<String> getFaces() {
+        List<String> faces = new ArrayList<>();
+        for (BlockFace face : getMultipleFacing().getFaces()) {
+            faces.add(face.name());
+        }
+        return faces;
+    }
+
+    /////////
+    // Property Methods
+    ///////
+
+    @Override
+    public String getPropertyString() {
+        return !getFaces().isEmpty() ? new ListTag(getFaces()).identify() : null;
+    }
+
+    @Override
+    public String getPropertyId() {
+        return "faces";
+    }
+
+    ///////////
+    // ObjectTag Attributes
+    ////////
+
+    @Override
+    public String getAttribute(Attribute attribute) {
+        if (attribute == null) {
+            return null;
+        }
+
+        // <--[tag]
+        // @attribute <MaterialTag.allowed_faces>
+        // @returns ListTag
+        // @group properties
+        // @description
+        // If the material can have faces, returns which faces the material's texture can be displayed on.
+        // A list of all faces can be found here: <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/block/BlockFace.html>
+        // -->
+        if (attribute.startsWith("allowed_faces")) {
+            ListTag allowedFaces = new ListTag();
+            for (BlockFace face : getMultipleFacing().getAllowedFaces()) {
+                allowedFaces.add(face.name());
+            }
+            return allowedFaces.getAttribute(attribute.fulfill(1));
+        }
+
+        // <--[tag]
+        // @attribute <MaterialTag.has_face[<face>]>
+        // @returns ElementTag(Boolean)
+        // @mechanism MaterialTag.faces
+        // @group properties
+        // @description
+        // If the material can have faces, returns whether the material's texture are displayed on this face.
+        // A list of all faces can be found here: <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/block/BlockFace.html>
+        // -->
+        if (attribute.startsWith("has_face") && attribute.hasContext(1)) {
+            String input = attribute.getContext(1);
+            BlockFace face;
+            try {
+                face = BlockFace.valueOf(input.toUpperCase());
+            }
+            catch (IllegalArgumentException e) {
+                Debug.echoError("Invalid face!");
+                return null;
+            }
+        }
+
+        // <--[tag]
+        // @attribute <MaterialTag.faces>
+        // @returns ListTag
+        // @mechanism MaterialTag.faces
+        // @group properties
+        // @description
+        // If the material can have faces, returns a list of faces that the material's texture are displayed on.
+        // A list of all faces can be found here: <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/block/BlockFace.html>
+        // -->
+        if (attribute.startsWith("faces")) {
+            return new ListTag(getFaces()).getAttribute(attribute.fulfill(1));
+        }
+
+        return null;
+    }
+
+    @Override
+    public void adjust(Mechanism mechanism) {
+
+        // <--[mechanism]
+        // @object MaterialTag
+        // @name faces
+        // @input ListTag
+        // @description
+        // Sets the faces that the material's textures are displayed on.
+        // A list of all faces can be found here: <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/block/BlockFace.html>
+        // @tags
+        // <MaterialTag.faces>
+        // <MaterialTag.allowed_faces>
+        // <MaterialTag.has_face[<face>]>
+        // -->
+        if (mechanism.matches("faces") && mechanism.requireObject(ListTag.class)) {
+            List<BlockFace> validFaces = new ArrayList<>();
+            for (String input : mechanism.valueAsType(ListTag.class)) {
+                BlockFace face;
+                try {
+                    face = BlockFace.valueOf(input.toUpperCase());
+                }
+                catch (IllegalArgumentException e) {
+                    continue;
+                }
+                if (!getMultipleFacing().getAllowedFaces().contains(face)) {
+                    continue;
+                }
+                validFaces.add(face);
+            }
+            if (validFaces.isEmpty()) {
+                Debug.echoError("No valid face was specified!");
+                return;
+            }
+            for (BlockFace face : getMultipleFacing().getFaces()) {
+                getMultipleFacing().setFace(face, false);
+            }
+            for (BlockFace face : validFaces) {
+                getMultipleFacing().setFace(face, true);
+            }
+        }
+    }
+}

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialOpen.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialOpen.java
@@ -1,0 +1,104 @@
+package com.denizenscript.denizen.objects.properties.material;
+
+import com.denizenscript.denizen.objects.MaterialTag;
+import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.objects.properties.Property;
+import com.denizenscript.denizencore.tags.Attribute;
+import org.bukkit.block.data.Openable;
+
+public class MaterialOpen implements Property {
+
+    public static boolean describes(ObjectTag material) {
+        return material instanceof MaterialTag
+                && ((MaterialTag) material).hasModernData()
+                && ((MaterialTag) material).getModernData().data instanceof Openable;
+    }
+
+    public static MaterialOpen getFrom(ObjectTag material) {
+        if (!describes(material)) {
+            return null;
+        }
+        return new MaterialOpen((MaterialTag) material);
+    }
+
+    public static final String[] handledTags = new String[] {
+            "is_open"
+    };
+
+    public static final String[] handledMechs = new String[] {
+            "is_open"
+    };
+
+
+    ///////////////////
+    // Instance Fields and Methods
+    /////////////
+
+    private MaterialOpen(MaterialTag material) {
+        this.material = material;
+    }
+
+    private MaterialTag material;
+
+    private Openable getOpenable() {
+        return (Openable) material.getModernData().data;
+    }
+
+    /////////
+    // Property Methods
+    ///////
+
+    @Override
+    public String getPropertyString() {
+        return getOpenable().isOpen() ? "true" : null;
+    }
+
+    @Override
+    public String getPropertyId() {
+        return "is_open";
+    }
+
+    ///////////
+    // ObjectTag Attributes
+    ////////
+
+    @Override
+    public String getAttribute(Attribute attribute) {
+        if (attribute == null) {
+            return null;
+        }
+
+        // <--[tag]
+        // @attribute <MaterialTag.is_open>
+        // @returns ElementTag(Boolean)
+        // @mechanism MaterialTag.is_open
+        // @group properties
+        // @description
+        // If the material is a door, trapdoor, or fence gate, returns whether this material is opened.
+        // -->
+        if (attribute.startsWith("is_open")) {
+            return new ElementTag(getOpenable().isOpen()).getAttribute(attribute.fulfill(1));
+        }
+
+        return null;
+    }
+
+    @Override
+    public void adjust(Mechanism mechanism) {
+
+        // <--[mechanism]
+        // @object MaterialTag
+        // @name is_open
+        // @input ElementTag(Boolean)
+        // @description
+        // If the material is a door, trapdoor, or fence gate, sets whether this material is opened.
+        // @tags
+        // <MaterialTag.is_open>
+        // -->
+        if (mechanism.matches("is_open") && mechanism.requireBoolean()) {
+            getOpenable().setOpen(mechanism.getValue().asBoolean());
+        }
+    }
+}

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialOpen.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialOpen.java
@@ -24,11 +24,11 @@ public class MaterialOpen implements Property {
     }
 
     public static final String[] handledTags = new String[] {
-            "is_open"
+            "open"
     };
 
     public static final String[] handledMechs = new String[] {
-            "is_open"
+            "open"
     };
 
 
@@ -57,7 +57,7 @@ public class MaterialOpen implements Property {
 
     @Override
     public String getPropertyId() {
-        return "is_open";
+        return "open";
     }
 
     ///////////
@@ -71,14 +71,14 @@ public class MaterialOpen implements Property {
         }
 
         // <--[tag]
-        // @attribute <MaterialTag.is_open>
+        // @attribute <MaterialTag.open>
         // @returns ElementTag(Boolean)
-        // @mechanism MaterialTag.is_open
+        // @mechanism MaterialTag.open
         // @group properties
         // @description
         // If the material is a door, trapdoor, or fence gate, returns whether this material is opened.
         // -->
-        if (attribute.startsWith("is_open")) {
+        if (attribute.startsWith("open")) {
             return new ElementTag(getOpenable().isOpen()).getAttribute(attribute.fulfill(1));
         }
 
@@ -90,14 +90,14 @@ public class MaterialOpen implements Property {
 
         // <--[mechanism]
         // @object MaterialTag
-        // @name is_open
+        // @name open
         // @input ElementTag(Boolean)
         // @description
         // If the material is a door, trapdoor, or fence gate, sets whether this material is opened.
         // @tags
-        // <MaterialTag.is_open>
+        // <MaterialTag.open>
         // -->
-        if (mechanism.matches("is_open") && mechanism.requireBoolean()) {
+        if (mechanism.matches("open") && mechanism.requireBoolean()) {
             getOpenable().setOpen(mechanism.getValue().asBoolean());
         }
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialOrientation.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialOrientation.java
@@ -1,0 +1,129 @@
+package com.denizenscript.denizen.objects.properties.material;
+
+import com.denizenscript.denizen.objects.MaterialTag;
+import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.objects.core.ListTag;
+import com.denizenscript.denizencore.objects.properties.Property;
+import com.denizenscript.denizencore.tags.Attribute;
+import org.bukkit.Axis;
+import org.bukkit.block.data.Orientable;
+
+public class MaterialOrientation implements Property {
+
+    public static boolean describes(ObjectTag material) {
+        return material instanceof MaterialTag
+                && ((MaterialTag) material).hasModernData()
+                && ((MaterialTag) material).getModernData().data instanceof Orientable;
+    }
+
+    public static MaterialOrientation getFrom(ObjectTag material) {
+        if (!describes(material)) {
+            return null;
+        }
+        return new MaterialOrientation((MaterialTag) material);
+    }
+
+    public static final String[] handledTags = new String[] {
+            "valid_orientations", "orientation"
+    };
+
+    public static final String[] handledMechs = new String[] {
+            "orientation"
+    };
+
+
+    ///////////////////
+    // Instance Fields and Methods
+    /////////////
+
+    private MaterialOrientation(MaterialTag material) {
+        this.material = material;
+    }
+
+    private MaterialTag material;
+
+    private Orientable getOrientable() {
+        return (Orientable) material.getModernData().data;
+    }
+
+    private String getAxis() {
+        return getOrientable().getAxis().name();
+    }
+
+    /////////
+    // Property Methods
+    ///////
+
+    @Override
+    public String getPropertyString() {
+        return getAxis();
+    }
+
+    @Override
+    public String getPropertyId() {
+        return "orientation";
+    }
+
+    ///////////
+    // ObjectTag Attributes
+    ////////
+
+    @Override
+    public String getAttribute(Attribute attribute) {
+        if (attribute == null) {
+            return null;
+        }
+
+        // <--[tag]
+        // @attribute <MaterialTag.valid_orientations>
+        // @returns ListTag
+        // @group properties
+        // @description
+        // If the material can be oriented along an axis, returns the axes that the material can be oriented on.
+        // Can be X, Y, and/or Z.
+        // -->
+        if (attribute.startsWith("valid_orientations")) {
+            ListTag axes = new ListTag();
+            for (Axis axis : getOrientable().getAxes()) {
+                axes.add(axis.name());
+            }
+            return axes.getAttribute(attribute.fulfill(1));
+        }
+
+        // <--[tag]
+        // @attribute <MaterialTag.orientation>
+        // @returns ElementTag
+        // @mechanism MaterialTag.orientation
+        // @group properties
+        // @description
+        // If the material can be oriented along an axis, returns the axis on which the material is oriented.
+        // Can be X, Y, or Z.
+        // -->
+        if (attribute.startsWith("orientation")) {
+            return new ElementTag(getAxis()).getAttribute(attribute.fulfill(1));
+        }
+
+        return null;
+    }
+
+    @Override
+    public void adjust(Mechanism mechanism) {
+
+        // <--[mechanism]
+        // @object MaterialTag
+        // @name orientation
+        // @input ElementTag
+        // @description
+        // If the material can be oriented along an axis, sets the axis on which the material is oriented on.
+        // Can be X, Y, or Z.
+        // @tags
+        // <MaterialTag.valid_orientations>
+        // <MaterialTag.orientation>
+        // -->
+        if (mechanism.matches("orientation") && mechanism.requireEnum(false, Axis.values())) {
+            getOrientable().setAxis(Axis.valueOf(mechanism.getValue().asString().toUpperCase()));
+        }
+    }
+}

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialRailShape.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialRailShape.java
@@ -1,0 +1,141 @@
+package com.denizenscript.denizen.objects.properties.material;
+
+import com.denizenscript.denizen.objects.MaterialTag;
+import com.denizenscript.denizen.utilities.debugging.Debug;
+import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.objects.core.ListTag;
+import com.denizenscript.denizencore.objects.properties.Property;
+import com.denizenscript.denizencore.tags.Attribute;
+import org.bukkit.block.data.Rail;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MaterialRailShape implements Property {
+
+    public static boolean describes(ObjectTag material) {
+        return material instanceof MaterialTag
+                && ((MaterialTag) material).hasModernData()
+                && ((MaterialTag) material).getModernData().data instanceof Rail;
+    }
+
+    public static MaterialRailShape getFrom(ObjectTag material) {
+        if (!describes(material)) {
+            return null;
+        }
+        return new MaterialRailShape((MaterialTag) material);
+    }
+
+    public static final String[] handledTags = new String[] {
+            "valid_rail_shapes", "rail_shape"
+    };
+
+    public static final String[] handledMechs = new String[] {
+            "rail_shape"
+    };
+
+
+    ///////////////////
+    // Instance Fields and Methods
+    /////////////
+
+    private MaterialRailShape(MaterialTag material) {
+        this.material = material;
+    }
+
+    private MaterialTag material;
+
+    private Rail getRail() {
+        return (Rail) material.getModernData().data;
+    }
+
+    private List<String> getValidRails() {
+        List<String> railShapes = new ArrayList<>();
+        for (Rail.Shape shape : getRail().getShapes()) {
+            railShapes.add(shape.name());
+        }
+        return railShapes;
+    }
+
+    private String getShape() {
+        return getRail().getShape().name();
+    }
+
+    /////////
+    // Property Methods
+    ///////
+
+    @Override
+    public String getPropertyString() {
+        return getShape();
+    }
+
+    @Override
+    public String getPropertyId() {
+        return "rail_shape";
+    }
+
+    ///////////
+    // ObjectTag Attributes
+    ////////
+
+    @Override
+    public String getAttribute(Attribute attribute) {
+        if (attribute == null) {
+            return null;
+        }
+
+        // <--[tag]
+        // @attribute <MaterialTag.valid_rail_shapes>
+        // @returns ListTag
+        // @group properties
+        // @description
+        // If the material is a rail, returns a list of all rail shapes that are applicable to this material.
+        // A list of valid rail shapes can be found here: <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/block/data/Rail.Shape.html>
+        // -->
+        if (attribute.startsWith("valid_rail_shapes")) {
+            return new ListTag(getValidRails()).getAttribute(attribute.fulfill(1));
+        }
+
+        // <--[tag]
+        // @attribute <MaterialTag.rail_shape>
+        // @returns ElementTag
+        // @mechanism MaterialTag.rail_shape
+        // @group properties
+        // @description
+        // If the material is a rail, returns the material's rail shape.
+        // A list of valid rail shapes can be found here: <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/block/data/Rail.Shape.html>
+        // -->
+        if (attribute.startsWith("rail_shape")) {
+            return new ElementTag(getRail().getShape().name()).getAttribute(attribute.fulfill(1));
+        }
+
+        return null;
+    }
+
+    @Override
+    public void adjust(Mechanism mechanism) {
+
+        // <--[mechanism]
+        // @object MaterialTag
+        // @name rail_shape
+        // @input ElementTag
+        // @description
+        // If the material is a rail, sets the material's rail shape.
+        // A list of valid rail shapes can be found here: <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/block/data/Rail.Shape.html>
+        // @tags
+        // <MaterialTag.valid_rail_shapes>
+        // <MaterialTag.rail_shape>
+        // -->
+        if (mechanism.matches("rail_shape") && mechanism.requireEnum(false, Rail.Shape.values())) {
+            String value = mechanism.getValue().asString().toUpperCase();
+            if (!getValidRails().contains(value)) {
+                Debug.echoError("This shape is not applicable to this rail!");
+                return;
+            }
+            getRail().setShape(Rail.Shape.valueOf(value));
+        }
+    }
+}

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialRedstonePower.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialRedstonePower.java
@@ -1,0 +1,131 @@
+package com.denizenscript.denizen.objects.properties.material;
+
+import com.denizenscript.denizen.objects.MaterialTag;
+import com.denizenscript.denizen.utilities.debugging.Debug;
+import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.objects.properties.Property;
+import com.denizenscript.denizencore.tags.Attribute;
+import org.bukkit.block.data.AnaloguePowerable;
+
+public class MaterialRedstonePower implements Property {
+
+    public static boolean describes(ObjectTag material) {
+        return material instanceof MaterialTag
+                && ((MaterialTag) material).hasModernData()
+                && ((MaterialTag) material).getModernData().data instanceof AnaloguePowerable;
+    }
+
+    public static MaterialRedstonePower getFrom(ObjectTag material) {
+        if (!describes(material)) {
+            return null;
+        }
+        return new MaterialRedstonePower((MaterialTag) material);
+    }
+
+    public static final String[] handledTags = new String[] {
+            "redstone_power", "max_redstone_power"
+    };
+
+    public static final String[] handledMechs = new String[] {
+            "redstone_power"
+    };
+
+
+    ///////////////////
+    // Instance Fields and Methods
+    /////////////
+
+    private MaterialRedstonePower(MaterialTag material) {
+        this.material = material;
+    }
+
+    private MaterialTag material;
+
+    private AnaloguePowerable getPowerable() {
+        return (AnaloguePowerable) material.getModernData().data;
+    }
+
+    private int getPower() {
+        return getPowerable().getPower();
+    }
+
+    private int getMaxPower() {
+        return getPowerable().getMaximumPower();
+    }
+
+    /////////
+    // Property Methods
+    ///////
+
+    @Override
+    public String getPropertyString() {
+        return getPower() != 0 ? String.valueOf(getPower()) : null;
+    }
+
+    @Override
+    public String getPropertyId() {
+        return "redstone_power";
+    }
+
+    ///////////
+    // ObjectTag Attributes
+    ////////
+
+    @Override
+    public String getAttribute(Attribute attribute) {
+        if (attribute == null) {
+            return null;
+        }
+
+        // <--[tag]
+        // @attribute <MaterialTag.redstone_power>
+        // @returns ElementTag(Number)
+        // @mechanism MaterialTag.redstone_power
+        // @group properties
+        // @description
+        // If the material can have redstone power sent through it, returns the current power sent by this material.
+        // -->
+        if (attribute.startsWith("redstone_power")) {
+            return new ElementTag(getPower()).getAttribute(attribute.fulfill(1));
+        }
+
+        // <--[tag]
+        // @attribute <MaterialTag.max_redstone_power>
+        // @returns ElementTag(Number)
+        // @mechanism MaterialTag.power
+        // @group properties
+        // @description
+        // If the material can have redstone power sent through it, returns the maximum power that the material can send.
+        // -->
+        if (attribute.startsWith("max_redstone_power")) {
+            return new ElementTag(getMaxPower()).getAttribute(attribute.fulfill(1));
+        }
+
+        return null;
+    }
+
+    @Override
+    public void adjust(Mechanism mechanism) {
+
+        // <--[mechanism]
+        // @object MaterialTag
+        // @name redstone_power
+        // @input ElementTag(Number)
+        // @description
+        // Sets the redstone power the material sends, if it can send redstone power.
+        // @tags
+        // <MaterialTag.redstone_power>
+        // <MaterialTag.max_redstone_power>
+        // -->
+        if (mechanism.matches("redstone_power") && mechanism.requireInteger()) {
+            int power = mechanism.getValue().asInt();
+            if (power < 0 || power > getMaxPower()) {
+                Debug.echoError("Redstone power for material '" + material.getMaterial().name() + "' must be between 0 and " + getMaxPower() + "!");
+                return;
+            }
+            getPowerable().setPower(power);
+        }
+    }
+}

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialRotation.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialRotation.java
@@ -1,0 +1,113 @@
+package com.denizenscript.denizen.objects.properties.material;
+
+import com.denizenscript.denizen.objects.MaterialTag;
+import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.objects.properties.Property;
+import com.denizenscript.denizencore.tags.Attribute;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.data.Rotatable;
+
+public class MaterialRotation implements Property {
+
+    public static boolean describes(ObjectTag material) {
+        return material instanceof MaterialTag
+                && ((MaterialTag) material).hasModernData()
+                && ((MaterialTag) material).getModernData().data instanceof Rotatable;
+    }
+
+    public static MaterialRotation getFrom(ObjectTag material) {
+        if (!describes(material)) {
+            return null;
+        }
+        return new MaterialRotation((MaterialTag) material);
+    }
+
+    public static final String[] handledTags = new String[] {
+            "rotation"
+    };
+
+    public static final String[] handledMechs = new String[] {
+            "rotation"
+    };
+
+
+    ///////////////////
+    // Instance Fields and Methods
+    /////////////
+
+    private MaterialRotation(MaterialTag material) {
+        this.material = material;
+    }
+
+    private MaterialTag material;
+
+    private Rotatable getRotatable() {
+        return (Rotatable) material.getModernData().data;
+    }
+
+    private String getRotation() {
+        return getRotatable().getRotation().name();
+    }
+
+    /////////
+    // Property Methods
+    ///////
+
+    @Override
+    public String getPropertyString() {
+        return getRotatable().getRotation() != BlockFace.SELF ? getRotation() : null;
+    }
+
+    @Override
+    public String getPropertyId() {
+        return "rotation";
+    }
+
+    ///////////
+    // ObjectTag Attributes
+    ////////
+
+    @Override
+    public String getAttribute(Attribute attribute) {
+        if (attribute == null) {
+            return null;
+        }
+
+        // <--[tag]
+        // @attribute <MaterialTag.rotation>
+        // @returns Element
+        // @mechanism MaterialTag.rotation
+        // @group properties
+        // @description
+        // If the material is rotatable, returns the material's rotation.
+        // The rotation can be one of: <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/block/BlockFace.html>
+        // -->
+        if (attribute.startsWith("rotation")) {
+            return new ElementTag(getRotation()).getAttribute(attribute.fulfill(1));
+        }
+
+        return null;
+    }
+
+    @Override
+    public void adjust(Mechanism mechanism) {
+
+        // <--[mechanism]
+        // @object MaterialTag
+        // @name rotation
+        // @input ElementTag
+        // @description
+        // If the material is rotatable, set the material's rotation.
+        // The rotation can be one of: <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/block/BlockFace.html>
+        // NOTE: The rotation should consist of only compass directions. Values like "DOWN" are not valid!
+        // @tags
+        // <MaterialTag.rotation>
+        // -->
+        if (mechanism.matches("rotation") && mechanism.requireEnum(false, BlockFace.values())) {
+            BlockFace face = BlockFace.valueOf(mechanism.getValue().asString().toUpperCase());
+            getRotatable().setRotation(face);
+        }
+    }
+}

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialSnowy.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialSnowy.java
@@ -1,0 +1,104 @@
+package com.denizenscript.denizen.objects.properties.material;
+
+import com.denizenscript.denizen.objects.MaterialTag;
+import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.objects.properties.Property;
+import com.denizenscript.denizencore.tags.Attribute;
+import org.bukkit.block.data.Snowable;
+
+public class MaterialSnowy implements Property {
+
+    public static boolean describes(ObjectTag material) {
+        return material instanceof MaterialTag
+                && ((MaterialTag) material).hasModernData()
+                && ((MaterialTag) material).getModernData().data instanceof Snowable;
+    }
+
+    public static MaterialSnowy getFrom(ObjectTag material) {
+        if (!describes(material)) {
+            return null;
+        }
+        return new MaterialSnowy((MaterialTag) material);
+    }
+
+    public static final String[] handledTags = new String[] {
+            "snowy"
+    };
+
+    public static final String[] handledMechs = new String[] {
+            "snowy"
+    };
+
+
+    ///////////////////
+    // Instance Fields and Methods
+    /////////////
+
+    private MaterialSnowy(MaterialTag material) {
+        this.material = material;
+    }
+
+    private MaterialTag material;
+
+    private Snowable getSnowable() {
+        return (Snowable) material.getModernData().data;
+    }
+
+    /////////
+    // Property Methods
+    ///////
+
+    @Override
+    public String getPropertyString() {
+        return getSnowable().isSnowy() ? "true" : null;
+    }
+
+    @Override
+    public String getPropertyId() {
+        return "snowy";
+    }
+
+    ///////////
+    // ObjectTag Attributes
+    ////////
+
+    @Override
+    public String getAttribute(Attribute attribute) {
+        if (attribute == null) {
+            return null;
+        }
+
+        // <--[tag]
+        // @attribute <MaterialTag.snowy>
+        // @returns ElementTag(Boolean)
+        // @mechanism MaterialTag.snowy
+        // @group properties
+        // @description
+        // Returns whether this material is covered with snow, if it has a special texture when snow is on top of it.
+        // -->
+        if (attribute.startsWith("snowy")) {
+            return new ElementTag(getSnowable().isSnowy()).getAttribute(attribute.fulfill(1));
+        }
+
+        return null;
+    }
+
+    @Override
+    public void adjust(Mechanism mechanism) {
+
+        // <--[mechanism]
+        // @object MaterialTag
+        // @name snowy
+        // @input ElementTag(Boolean)
+        // @description
+        // If the material has a special texture when snow is on top of it, sets whether this material will have that special texture.
+        // @tags
+        // <MaterialTag.snowy>
+        // -->
+        if (mechanism.matches("snowy") && mechanism.requireBoolean()) {
+            getSnowable().setSnowy(mechanism.getValue().asBoolean());
+        }
+    }
+}

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialWaterlogged.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialWaterlogged.java
@@ -1,0 +1,104 @@
+package com.denizenscript.denizen.objects.properties.material;
+
+import com.denizenscript.denizen.objects.MaterialTag;
+import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.objects.properties.Property;
+import com.denizenscript.denizencore.tags.Attribute;
+import org.bukkit.block.data.Waterlogged;
+
+public class MaterialWaterlogged implements Property {
+
+    public static boolean describes(ObjectTag material) {
+        return material instanceof MaterialTag
+                && ((MaterialTag) material).hasModernData()
+                && ((MaterialTag) material).getModernData().data instanceof Waterlogged;
+    }
+
+    public static MaterialWaterlogged getFrom(ObjectTag material) {
+        if (!describes(material)) {
+            return null;
+        }
+        return new MaterialWaterlogged((MaterialTag) material);
+    }
+
+    public static final String[] handledTags = new String[] {
+            "waterlogged"
+    };
+
+    public static final String[] handledMechs = new String[] {
+            "waterlogged"
+    };
+
+
+    ///////////////////
+    // Instance Fields and Methods
+    /////////////
+
+    private MaterialWaterlogged(MaterialTag material) {
+        this.material = material;
+    }
+
+    private MaterialTag material;
+
+    private Waterlogged getWaterlogged() {
+        return (Waterlogged) material.getModernData().data;
+    }
+
+    /////////
+    // Property Methods
+    ///////
+
+    @Override
+    public String getPropertyString() {
+        return getWaterlogged().isWaterlogged() ? "true" : null;
+    }
+
+    @Override
+    public String getPropertyId() {
+        return "waterlogged";
+    }
+
+    ///////////
+    // ObjectTag Attributes
+    ////////
+
+    @Override
+    public String getAttribute(Attribute attribute) {
+        if (attribute == null) {
+            return null;
+        }
+
+        // <--[tag]
+        // @attribute <MaterialTag.waterlogged>
+        // @returns ElementTag(Boolean)
+        // @mechanism MaterialTag.waterlogged
+        // @group properties
+        // @description
+        // Returns whether the material is waterlogged, if it can be waterlogged.
+        // -->
+        if (attribute.startsWith("waterlogged")) {
+            return new ElementTag(getWaterlogged().isWaterlogged()).getAttribute(attribute.fulfill(1));
+        }
+
+        return null;
+    }
+
+    @Override
+    public void adjust(Mechanism mechanism) {
+
+        // <--[mechanism]
+        // @object MaterialTag
+        // @name waterlogged
+        // @input ElementTag(Boolean)
+        // @description
+        // If the material is waterloggable, sets whether the material is waterlogged.
+        // @tags
+        // <MaterialTag.waterlogged>
+        // -->
+        if (mechanism.matches("waterlogged") && mechanism.requireBoolean()) {
+            getWaterlogged().setWaterlogged(mechanism.getValue().asBoolean());
+        }
+    }
+}


### PR DESCRIPTION
This should cover everything under this package: https://hub.spigotmc.org/javadocs/spigot/org/bukkit/block/data/package-summary.html

The `block.data.type` package stuff will come in approximately 3 new PRs.