### PR TITLE
Revert "fix/improve scoreboard command, 'scores' parameter"

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/nms/abstracts/Sidebar.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/abstracts/Sidebar.java
@@ -4,52 +4,45 @@ import org.bukkit.entity.Player;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 public abstract class Sidebar {
 
-    public static class SidebarLine {
-
-        public SidebarLine(String _text, int _score) {
-            text = _text;
-            score = _score;
-        }
-
-        public String text;
-
-        public int score;
-    }
-
-    public static final int MAX_LENGTH = 15;
     protected final Player player;
     protected String title;
-    protected String[] lines = new String[MAX_LENGTH];
-    protected int[] scores = new int[MAX_LENGTH];
-    public int setCount = 0;
+    protected String[] lines;
+    protected int[] scores;
+    protected int start;
+    protected int increment;
 
     public Sidebar(Player player) {
         this.player = player;
         setTitle("");
+        this.lines = new String[15];
+        this.scores = new int[15];
+        this.start = Integer.MIN_VALUE;
+        this.increment = -1;
     }
 
     public String getTitle() {
         return title;
     }
 
-    public List<SidebarLine> getLines() {
-        List<SidebarLine> toReturn = new ArrayList<>(MAX_LENGTH);
-        for (int i = 0; i < setCount; i++) {
-            toReturn.add(new SidebarLine(lines[i], scores[i]));
-        }
-        return toReturn;
-    }
-
-    public List<String> getLinesText() {
+    public List<String> getLines() {
         return new ArrayList<>(Arrays.asList(lines));
     }
 
     public int[] getScores() {
         return scores;
+    }
+
+    public int getStart() {
+        return start;
+    }
+
+    public int getIncrement() {
+        return increment;
     }
 
     public final void setTitle(String title) {
@@ -64,19 +57,29 @@ public abstract class Sidebar {
 
     protected abstract void setDisplayName(String title);
 
-    public void setLines(List<SidebarLine> lines) {
-        setCount = Math.min(lines.size(), MAX_LENGTH);
-        for (int i = 0; i < setCount; i++) {
-            String line = lines.get(i).text;
+    public void setStart(int start) {
+        this.start = start;
+    }
+
+    public void setIncrement(int increment) {
+        this.increment = increment;
+    }
+
+    public void setLines(List<String> lines) {
+        lines.removeAll(Collections.singleton((String) null));
+        this.lines = new String[15];
+        this.scores = new int[15];
+        int score = this.start;
+        if (score == Integer.MIN_VALUE) {
+            score = lines.size();
+        }
+        for (int i = 0; i < lines.size() && i < this.lines.length; i++, score += this.increment) {
+            String line = lines.get(i);
             if (line.length() > 40) {
                 line = line.substring(0, 40);
             }
             this.lines[i] = line;
-            this.scores[i] = lines.get(i).score;
-        }
-        for (int i = setCount; i < MAX_LENGTH; i++) {
-            this.lines[i] = null;
-            this.scores[i] = 0;
+            this.scores[i] = score;
         }
     }
 

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/PlayerTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/PlayerTag.java
@@ -1596,7 +1596,7 @@ public class PlayerTag implements ObjectTag, Adjustable, EntityFormObject {
             if (sidebar == null) {
                 return null;
             }
-            return new ListTag(sidebar.getLinesText()).getAttribute(attribute.fulfill(2));
+            return new ListTag(sidebar.getLines()).getAttribute(attribute.fulfill(2));
         }
 
         // <--[tag]
@@ -1630,6 +1630,34 @@ public class PlayerTag implements ObjectTag, Adjustable, EntityFormObject {
                 scores.add(String.valueOf(score));
             }
             return scores.getAttribute(attribute.fulfill(2));
+        }
+
+        // <--[tag]
+        // @attribute <p@player.sidebar.start>
+        // @returns Element(Number)
+        // @description
+        // Returns the current start score set on the player's Sidebar via the Sidebar command.
+        // -->
+        if (attribute.startsWith("sidebar.start")) {
+            Sidebar sidebar = SidebarCommand.getSidebar(this);
+            if (sidebar == null) {
+                return null;
+            }
+            return new ElementTag(sidebar.getStart()).getAttribute(attribute.fulfill(2));
+        }
+
+        // <--[tag]
+        // @attribute <p@player.sidebar.increment>
+        // @returns Element(Number)
+        // @description
+        // Returns the current score increment set on the player's Sidebar via the Sidebar command.
+        // -->
+        if (attribute.startsWith("sidebar.increment")) {
+            Sidebar sidebar = SidebarCommand.getSidebar(this);
+            if (sidebar == null) {
+                return null;
+            }
+            return new ElementTag(sidebar.getIncrement()).getAttribute(attribute.fulfill(2));
         }
 
         // <--[tag]

--- a/v1_14/src/main/java/com/denizenscript/denizen/nms/v1_14/impl/SidebarImpl.java
+++ b/v1_14/src/main/java/com/denizenscript/denizen/nms/v1_14/impl/SidebarImpl.java
@@ -40,6 +40,7 @@ public class SidebarImpl extends Sidebar {
             ScoreboardScore score = new ScoreboardScore(dummyScoreboard, this.obj1, line);
             score.setScore(this.scores[i]);
             // CraftScoreboardManager setPlayerBoard
+            // new PacketPlayOutScoreboardScore(ScoreboardServer.Action.CHANGE, scoreboardscore.getObjective().getName(), scoreboardscore.getPlayerName(), scoreboardscore.getScore()));
             PacketHelperImpl.sendPacket(player, new PacketPlayOutScoreboardScore(ScoreboardServer.Action.CHANGE, score.getObjective().getName(), score.getPlayerName(), score.getScore()));
         }
         PacketHelperImpl.sendPacket(player, new PacketPlayOutScoreboardDisplayObjective(1, this.obj1));


### PR DESCRIPTION
This reverts commit 95d2fe70d525b3c0cc69f28d2b9ec7c971856b2f and part of commit 3df4f76452f72d46a3d1da3c0a17e652947ba9b7.

Currently, the sidebar command fails to accomplish its originally intended use cases. There are a few concepts worth looking at implementing ourselves, and perhaps this code was written with good intentions, but when confronted the author claimed that any breaking was "half" intentional. This does not conform with the goal of our project.

For #15, though is not a full fix as it removes the "scores" renamed argument. If it is to be added back, it should probably follow roughly the same behavior as upstream but not interfere with old code. This is beyond the scope of this PR.

Note that despite the naming of the upstream commit, neither that nor this involves the scoreboard command.