### PR TITLE
Add config option for tags auto-loading chunks

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/Settings.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/Settings.java
@@ -72,6 +72,7 @@ public class Settings {
         cache_worldScriptChatEventAsynchronous = config.getBoolean("Scripts.World.Events.On player chats.Use asynchronous event", false);
         cache_worldScriptTimeEventFrequency = DurationTag.valueOf(config.getString("Scripts.World.Events.On time changes.Frequency of check", "250t"));
         cache_blockTagsMaxBlocks = config.getInt("Tags.Block tags.Max blocks", 1000000);
+        cache_autoLoadChunks = config.getBoolean("Tags.Automatically load chunks", true);
         cache_chatHistoryMaxMessages = config.getInt("Tags.Chat history.Max messages", 10);
         cache_tagTimeout = config.getInt("Tags.Timeout", 10);
         cache_tagTimeoutSilent = config.getBoolean("Tags.Timeout when silent", false);
@@ -87,7 +88,7 @@ public class Settings {
             cache_healthTraitBlockDrops, cache_chatAsynchronous, cache_chatMustSeeNPC, cache_chatMustLookAtNPC,
             cache_chatGloballyIfFailedChatTriggers, cache_chatGloballyIfNoChatTriggers,
             cache_chatGloballyIfUninteractable, cache_worldScriptChatEventAsynchronous,
-            cache_tagTimeoutSilent, cache_packetInterception;
+            cache_tagTimeoutSilent, cache_packetInterception, cache_autoLoadChunks;
 
     private static String cache_getAlternateScriptPath, cache_scriptQueueSpeed, cache_healthTraitRespawnDelay,
             cache_engageTimeoutInSeconds, cache_chatMultipleTargetsFormat, cache_chatNoTargetFormat,
@@ -404,6 +405,10 @@ public class Settings {
 
     public static int blockTagsMaxBlocks() {
         return cache_blockTagsMaxBlocks;
+    }
+
+    public static boolean autoLoadChunks() {
+        return cache_autoLoadChunks;
     }
 
     public static int chatHistoryMaxMessages() {

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/ChunkTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/ChunkTag.java
@@ -1,5 +1,6 @@
 package com.denizenscript.denizen.objects;
 
+import com.denizenscript.denizen.Settings;
 import com.denizenscript.denizen.utilities.DenizenAPI;
 import com.denizenscript.denizen.utilities.blocks.FakeBlock;
 import com.denizenscript.denizen.utilities.debugging.Debug;
@@ -124,7 +125,7 @@ public class ChunkTag implements ObjectTag, Adjustable {
     Chunk cachedChunk;
 
     public Chunk getChunkForTag(Attribute attribute) {
-        if (!isLoaded()) {
+        if (!Settings.autoLoadChunks() && !isLoaded()) {
             if (!attribute.hasAlternative()) {
                 Debug.echoError("Cannot get chunk at " + chunkX + ", " + chunkZ + ": Chunk is not loaded. Use the 'chunkload' command to ensure the chunk is loaded.");
             }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
@@ -387,7 +387,7 @@ public class LocationTag extends org.bukkit.Location implements ObjectTag, Notab
             }
             return null;
         }
-        if (!isChunkLoaded()) {
+        if (!Settings.autoLoadChunks() && !isChunkLoaded()) {
             if (!attribute.hasAlternative()) {
                 Debug.echoError("LocationTag trying to read block, but cannot because the chunk is unloaded. Use the 'chunkload' command to ensure the chunk is loaded.");
             }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/inventory/InventoryHolder.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/inventory/InventoryHolder.java
@@ -124,9 +124,6 @@ public class InventoryHolder implements Property {
     }
 
     public void setHolder(LocationTag location) {
-        if (!location.isChunkLoaded()) {
-            return;
-        }
         inventory.setInventory(location.getBukkitInventory());
     }
 

--- a/plugin/src/main/resources/config.yml
+++ b/plugin/src/main/resources/config.yml
@@ -162,6 +162,11 @@ Tags:
   Block tags:
     # How many blocks can be read, max, before stopping the tag in place
     Max blocks: 1000000
+  # Whether tags should be allowed to automatically load currently unloaded chunks when attempting to access information.
+  # For example, when set to false, tags such as <chunk[10,10].entities> and <location[999999,70,999999,world].inventory> will error if the chunk is currently unloaded.
+  # If you are extremely worried about performance, it is recommended you disable this setting and modify your scripts appropriately, manually deciding when it is
+  # necessary to use the ChunkLoad command before accessing information.
+  Automatically load chunks: true
   Chat history:
     # How many player messages will be stored for each player (<player.chat_history>, etc.)
     Max messages: 10


### PR DESCRIPTION
Default true, fixes compatibility issues created by commit 889860cc0b89ffb01d1a5d5462c51009e7b3814a and commit 8956f48b7f5241851b68ced1599711f05177ea3b.

This also reverts the change to the `InventoryHolder` property, which can receive a patch if needed. It doesn't seem to fall under the scope of this PR other than reverting it as a relevant fix.