### PR TITLE
make radius in walk command actually work

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/WalkCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/WalkCommand.java
@@ -184,6 +184,8 @@ public class WalkCommand extends AbstractCommand implements Holdable {
                 }
 
                 if (radius != null) {
+                    npc.getNavigator().getLocalParameters().distanceMargin(radius.asDouble());
+                    npc.getNavigator().getLocalParameters().pathDistanceMargin(radius.asDouble());
                     npc.getNavigator().getLocalParameters().addRunCallback(WalkCommandCitizensEvents
                             .generateNewFlocker(npc.getCitizen(), radius.asDouble()));
                 }


### PR DESCRIPTION
As instructed by fullwall, these parameters also have to be set to the radius for the radius argument to actually work. Without these, the NPC will just use the default distance-margin as specified in the citizens config.

It is worth noting though that now if the radius argument actually works, it is pretty easy to get an npc stuck trying to reach a location that it cannot reach because it is underground or something, and the npc cannot get within the specified radius and can result in noticable lag. This might be an issue for all the people who have been used to the radius not working properly for a long time.