### PR TITLE
Allow copyblock command to copy cuboids

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/BukkitCommandRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/BukkitCommandRegistry.java
@@ -80,7 +80,7 @@ public class BukkitCommandRegistry extends CommandRegistry {
         registerCoreMember(ChunkLoadCommand.class, "CHUNKLOAD", "chunkload ({add}/remove/removeall) [<chunk>] (duration:<value>)", 1);
         registerCoreMember(CompassCommand.class, "COMPASS", "compass [<location>/reset]", 1);
         registerCoreMember(CooldownCommand.class, "COOLDOWN", "cooldown [<duration>] (global) (s:<script>)", 1);
-        registerCoreMember(CopyBlockCommand.class, "COPYBLOCK", "copyblock [<location>/<cuboid>] [to:<location>] (remove_original)", 1);
+        registerCoreMember(CopyBlockCommand.class, "COPYBLOCK", "copyblock [<location>/<cuboid>] [to:<location>] (remove_original) (delayed)", 1);
         if (Depends.citizens != null) {
             registerCoreMember(CreateCommand.class, "CREATE", "create [<entity>] [<name>] (<location>)", 1);
         }

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/BukkitCommandRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/BukkitCommandRegistry.java
@@ -80,7 +80,7 @@ public class BukkitCommandRegistry extends CommandRegistry {
         registerCoreMember(ChunkLoadCommand.class, "CHUNKLOAD", "chunkload ({add}/remove/removeall) [<chunk>] (duration:<value>)", 1);
         registerCoreMember(CompassCommand.class, "COMPASS", "compass [<location>/reset]", 1);
         registerCoreMember(CooldownCommand.class, "COOLDOWN", "cooldown [<duration>] (global) (s:<script>)", 1);
-        registerCoreMember(CopyBlockCommand.class, "COPYBLOCK", "copyblock [<location>/<cuboid>] [to:<location>] (remove_original) (delayed)", 1);
+        registerCoreMember(CopyBlockCommand.class, "COPYBLOCK", "copyblock [<location>/<cuboid>] (origin:<location>) [to:<location>] (remove_original) (delayed)", 1);
         if (Depends.citizens != null) {
             registerCoreMember(CreateCommand.class, "CREATE", "create [<entity>] [<name>] (<location>)", 1);
         }

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/CopyBlockCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/CopyBlockCommand.java
@@ -101,7 +101,7 @@ public class CopyBlockCommand extends AbstractCommand {
     @Override
     public void execute(ScriptEntry scriptEntry) {
 
-        ObjectTag sourceObject = (ObjectTag) scriptEntry.getObject("origin");
+        ObjectTag sourceObject = (ObjectTag) scriptEntry.getObject("source");
         LocationTag destination = (LocationTag) scriptEntry.getObject("destination");
         LocationTag originEntry = scriptEntry.hasObject("origin") ? (LocationTag) scriptEntry.getObject("origin") : null;
         ElementTag removeOriginal = (ElementTag) scriptEntry.getObject("remove");


### PR DESCRIPTION
Includes a "delayed" argument, which employs roughly the same delay tactics that the `modifyblock` command uses.

Tested to work on 1.12.2 and 1.14.4. Did not test on 1.13.2.