### PR TITLE
Add <InventoryTag.uniquifier>, remove unnecessary creation of unique IDs

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/objects/InventoryTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/InventoryTag.java
@@ -78,6 +78,9 @@ public class InventoryTag implements ObjectTag, Notable, Adjustable {
 
         public static HashMap<Long, InventoryTag> idTrackedInventories = new HashMap<>(512);
 
+        // Unizen-added
+        public static HashMap<Inventory, Long> matchInventoryWithId = new HashMap<>(512);
+
         public static long temporaryInventoryIdCounter = 0;
 
         public static HashMap<Inventory, InventoryTag> temporaryInventoryLinks = new HashMap<>(512);
@@ -123,6 +126,7 @@ public class InventoryTag implements ObjectTag, Notable, Adjustable {
                         InventoryTag removed = retainedInventoryLinks.remove(inv);
                         if (removed != null && removed.uniquifier != null) {
                             idTrackedInventories.remove(removed.uniquifier);
+                            matchInventoryWithId.remove(inv);
                             temporaryInventoryLinks.put(inv, removed);
                         }
                     }
@@ -130,21 +134,31 @@ public class InventoryTag implements ObjectTag, Notable, Adjustable {
             }, 1);
         }
 
-        public static void trackTemporaryInventory(Inventory inventory, InventoryTag tagForm) {
-            if (inventory == null || tagForm == null) {
+        public static void trackTemporaryInventory(InventoryTag tagForm) {
+            if (tagForm == null) {
+                return;
+            }
+            Inventory inventory = tagForm.inventory;
+            if (inventory == null) {
                 return;
             }
             if (!isGenericTrackable(tagForm)) {
                 return;
             }
+
             String title = NMSHandler.getInstance().getTitle(inventory);
             if (InventoryScriptHelper.notableInventories.containsKey(title)) {
                 return;
             }
-            if (tagForm.uniquifier == null) {
+            Long id = matchInventoryWithId.get(inventory);
+            if (id != null) {
+                tagForm.uniquifier = id;
+            }
+            else if (tagForm.uniquifier == null) {
                 tagForm.uniquifier = temporaryInventoryIdCounter++;
             }
             if (!idTrackedInventories.containsKey(tagForm.uniquifier)) {
+                matchInventoryWithId.put(inventory, tagForm.uniquifier);
                 idTrackedInventories.put(tagForm.uniquifier, tagForm);
             }
             temporaryInventoryLinks.put(inventory, tagForm);
@@ -165,7 +179,7 @@ public class InventoryTag implements ObjectTag, Notable, Adjustable {
         if (tagForm == null) {
             return;
         }
-        InventoryTrackerSystem.trackTemporaryInventory(tagForm.inventory, tagForm);
+        InventoryTrackerSystem.trackTemporaryInventory(tagForm);
     }
 
     public static void setupInventoryTracker() {
@@ -1414,7 +1428,6 @@ public class InventoryTag implements ObjectTag, Notable, Adjustable {
             return "in@" + NotableManager.getSavedId(this);
         }
         else {
-            trackTemporaryInventory(this);
             if (getIdType().equals("script")) {
                 if (uniquifier != null) {
                     return "in@" + idHolder + "[uniquifier=" + uniquifier + "]";

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/inventory/InventoryUniquifier.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/inventory/InventoryUniquifier.java
@@ -3,7 +3,9 @@ package com.denizenscript.denizen.objects.properties.inventory;
 import com.denizenscript.denizen.objects.InventoryTag;
 import com.denizenscript.denizencore.objects.Mechanism;
 import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.properties.Property;
+import com.denizenscript.denizencore.objects.properties.PropertyParser;
 
 public class InventoryUniquifier implements Property {
 
@@ -45,7 +47,13 @@ public class InventoryUniquifier implements Property {
     }
 
     public static void registerTags() {
-        // Intentionally no tags.
+        // Unizen-added property
+        PropertyParser.<InventoryUniquifier>registerTag("uniquifier", (attribute, property) -> {
+            if (property.inventory.uniquifier == null) {
+                return null;
+            }
+            return new ElementTag(property.inventory.uniquifier);
+        });
     }
 
     @Override


### PR DESCRIPTION
Fixes `<def[item].inventory>` from returning two separate inventories (separated by an arbitrarily-assigned "uniquifier") by not assigning every inventory a unique ID.